### PR TITLE
Prevent blocking of message card's shadow by adding padding

### DIFF
--- a/src/components/Messages/ChatMessages.vue
+++ b/src/components/Messages/ChatMessages.vue
@@ -133,12 +133,13 @@ export default {
     height: 100%;
     overflow-y: auto;
     gap: 16px;
-    margin: 68px 32px;
+    margin: 52px 16px;
 }
 
 .message-grid {
     display: grid;
     grid-gap: 16px;
     width: 100%;
+    padding: 16px;
 }
 </style>


### PR DESCRIPTION
Add padding to prevent the message card's shadow from being blocked.

**Before**:

<img width="865" alt="Screenshot 2023-05-12 at 21 52 59" src="https://github.com/sunner/ChatALL/assets/591094/27b0b542-bc7d-43dc-83b6-b08c3c3be9ff">


**After**:

<img width="881" alt="Screenshot 2023-05-12 at 21 52 43" src="https://github.com/sunner/ChatALL/assets/591094/f843fb45-655a-4a7a-80a6-5557405a84a9">

