### PR TITLE
Migrate two modal components to use the composition API

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -83,14 +83,14 @@
       </div>
     </footer>
     <MakeAvailableModal
+      v-model:open="isMakeAvailableOpen"
       :bot="clickedBot"
-      ref="makeAvailableModal"
       @done="checkAllBotsAvailability(clickedBot)"
-    ></MakeAvailableModal>
+    />
     <SettingsModal
-      ref="settingsModal"
+      v-model:open="isSettingsOpen"
       @done="checkAllBotsAvailability()"
-    ></SettingsModal>
+    />
   </div>
 </template>
 
@@ -136,7 +136,6 @@ export default {
   data() {
     return {
       prompt: "",
-      clickedBot: null,
       bots: [
         ChatGPT35Bot.getInstance(),
         ChatGPT4Bot.getInstance(),
@@ -156,6 +155,11 @@ export default {
         GradioAppBot.getInstance(),
       ],
       activeBots: {},
+
+      clickedBot: null,
+      isMakeAvailableOpen: false,
+
+      isSettingsOpen: false,
     };
   },
   methods: {
@@ -216,7 +220,7 @@ export default {
       if (!bot.isAvailable()) {
         this.clickedBot = bot;
         // Open the bot's settings dialog
-        this.$refs.makeAvailableModal.open();
+        this.isMakeAvailableOpen = true;
         selected = true;
       } else {
         selected = !this.selectedBots[botId];
@@ -258,7 +262,7 @@ export default {
       }
     },
     openSettingsModal() {
-      this.$refs.settingsModal.open();
+      this.isSettingsOpen = true;
     },
     // Send the prompt when the user presses enter and prevent the default behavior
     // But if the shift, ctrl, alt, or meta keys are pressed, do as default

--- a/src/components/MakeAvailableModal.vue
+++ b/src/components/MakeAvailableModal.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script setup>
-import { markRaw, ref, watch, defineProps, defineEmits } from "vue";
+import { markRaw, ref, watch } from "vue";
 
 const props = defineProps(["open", "bot"]);
 const emit = defineEmits(["update:open", "done"]);

--- a/src/components/MakeAvailableModal.vue
+++ b/src/components/MakeAvailableModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog v-model="show" persistent width="auto">
+  <v-dialog :model-value="open" persistent width="auto">
     <v-list v-if="botSettings !== null">
       <component :is="botSettings" />
       <v-card-actions>
@@ -10,40 +10,27 @@
   </v-dialog>
 </template>
 
-<script>
-import { markRaw } from "vue";
+<script setup>
+import { markRaw, ref, watch, defineProps, defineEmits } from "vue";
 
-export default {
-  props: {
-    bot: {
-      type: Object,
-      default: null,
-    },
+const props = defineProps(["open", "bot"]);
+const emit = defineEmits(["update:open", "done"]);
+
+const botSettings = ref(null);
+watch(
+  () => props.bot,
+  async (newBot) => {
+    if (newBot) {
+      botSettings.value = markRaw(await newBot.getSettingsComponent());
+    } else {
+      botSettings.value = null;
+    }
   },
-  data() {
-    return {
-      show: false,
-      botSettings: null,
-    };
-  },
-  watch: {
-    async bot(newBot) {
-      if (newBot) {
-        this.botSettings = markRaw(await newBot.getSettingsComponent());
-      } else {
-        this.botSettings = null;
-      }
-    },
-  },
-  methods: {
-    open() {
-      this.show = true;
-    },
-    onDone() {
-      this.show = false;
-      this.$emit("done");
-    },
-  },
+);
+
+const onDone = () => {
+  emit("update:open", false);
+  emit("done");
 };
 </script>
 

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -44,7 +44,7 @@
 </template>
 
 <script setup>
-import { computed, ref, defineProps, defineEmits } from "vue";
+import { computed, ref } from "vue";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 
@@ -66,12 +66,12 @@ const emit = defineEmits(["update:open", "done"]);
 const settings = [
   ChatGPTBotSettings,
   OpenAIAPIBotSettings,
-  BingChatBotSettings,
-  SparkBotSettings,
-  BardBotSettings,
-  MOSSBotSettings,
   WenxinQianfanBotSettings,
   GradioAppBotSettings,
+  BingChatBotSettings,
+  SparkBotSettings,
+  MOSSBotSettings,
+  BardBotSettings,
 ];
 
 const languages = ref([

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -18,9 +18,6 @@
           <v-list-subheader>{{ $t("settings.general") }}</v-list-subheader>
           <v-list-item>
             <v-list-item-title>{{ $t("settings.language") }}</v-list-item-title>
-            <v-list-item-subtitle>{{
-              $t("settings.languagePrompt")
-            }}</v-list-item-subtitle>
             <v-select
               :items="languages"
               item-title="name"
@@ -44,7 +41,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useStore } from "vuex";
 import { useI18n } from "vue-i18n";
 
@@ -57,7 +54,7 @@ import MOSSBotSettings from "@/components/BotSettings/MOSSBotSettings.vue";
 import WenxinQianfanBotSettings from "@/components/BotSettings/WenxinQianfanBotSettings.vue";
 import GradioAppBotSettings from "@/components/BotSettings/GradioAppBotSettings.vue";
 
-const { t: $t } = useI18n();
+const { t: $t, locale } = useI18n();
 const store = useStore();
 
 const props = defineProps(["open"]);
@@ -74,7 +71,7 @@ const settings = [
   BardBotSettings,
 ];
 
-const languages = ref([
+const languages = computed(() => [
   { name: $t("settings.auto"), code: "auto" },
   { name: "English", code: "en" },
   { name: "中文", code: "zh" },
@@ -83,6 +80,7 @@ const languages = ref([
 const lang = computed(() => store.state.lang);
 
 const setCurrentLanguage = (lang) => {
+  locale.value = lang;
   store.commit("setCurrentLanguage", lang);
 };
 const closeDialog = () => {

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog
-    v-model="dialog"
+    :model-value="props.open"
     fullscreen
     :scrim="false"
     transition="dialog-bottom-transition"
@@ -9,50 +9,44 @@
       <v-toolbar dark color="primary">
         <v-toolbar-title>{{ $t("settings.title") }}</v-toolbar-title>
         <v-spacer></v-spacer>
-        <v-btn icon dark @click="onClose">
+        <v-btn icon dark @click="closeDialog">
           <v-icon>mdi-close</v-icon>
         </v-btn>
       </v-toolbar>
       <v-list lines="two" subheader>
-        <v-list-subheader>{{ $t("settings.general") }}</v-list-subheader>
-        <v-list-item>
-          <v-list-item-title>{{ $t("settings.language") }}</v-list-item-title>
-          <v-list-item-subtitle>{{
-            $t("settings.languagePrompt")
-          }}</v-list-item-subtitle>
-          <v-select
-            v-model="lang"
-            :items="languages"
-            item-title="name"
-            item-value="code"
-            hide-details
-            @update:model-value="setCurrentLanguage($event)"
-          ></v-select>
-        </v-list-item>
+        <div class="section">
+          <v-list-subheader>{{ $t("settings.general") }}</v-list-subheader>
+          <v-list-item>
+            <v-list-item-title>{{ $t("settings.language") }}</v-list-item-title>
+            <v-list-item-subtitle>{{
+              $t("settings.languagePrompt")
+            }}</v-list-item-subtitle>
+            <v-select
+              :items="languages"
+              item-title="name"
+              item-value="code"
+              hide-details
+              :model-value="lang"
+              @update:model-value="setCurrentLanguage($event)"
+            ></v-select>
+          </v-list-item>
+        </div>
 
-        <v-divider></v-divider>
-        <ChatGPTBotSettings></ChatGPTBotSettings>
-        <v-divider></v-divider>
-        <OpenAIAPIBotSettings></OpenAIAPIBotSettings>
-        <v-divider></v-divider>
-        <WenxinQianfanBotSettings></WenxinQianfanBotSettings>
-        <v-divider></v-divider>
-        <GradioAppBotSettings></GradioAppBotSettings>
-        <v-divider></v-divider>
-        <BingChatBotSettings></BingChatBotSettings>
-        <v-divider></v-divider>
-        <SparkBotSettings></SparkBotSettings>
-        <v-divider></v-divider>
-        <MOSSBotSettings></MOSSBotSettings>
-        <v-divider></v-divider>
-        <BardBotSettings></BardBotSettings>
+        <template v-for="(setting, index) in settings" :key="index">
+          <v-divider></v-divider>
+          <div class="section">
+            <component :is="setting"></component>
+          </div>
+        </template>
       </v-list>
     </v-card>
   </v-dialog>
 </template>
 
-<script>
-import { mapState, mapMutations } from "vuex";
+<script setup>
+import { computed, ref, defineProps, defineEmits } from "vue";
+import { useStore } from "vuex";
+import { useI18n } from "vue-i18n";
 
 import ChatGPTBotSettings from "@/components/BotSettings/ChatGPTBotSettings.vue";
 import OpenAIAPIBotSettings from "@/components/BotSettings/OpenAIAPIBotSettings.vue";
@@ -63,39 +57,44 @@ import MOSSBotSettings from "@/components/BotSettings/MOSSBotSettings.vue";
 import WenxinQianfanBotSettings from "@/components/BotSettings/WenxinQianfanBotSettings.vue";
 import GradioAppBotSettings from "@/components/BotSettings/GradioAppBotSettings.vue";
 
-export default {
-  components: {
-    ChatGPTBotSettings,
-    OpenAIAPIBotSettings,
-    BingChatBotSettings,
-    SparkBotSettings,
-    MOSSBotSettings,
-    BardBotSettings,
-    WenxinQianfanBotSettings,
-    GradioAppBotSettings,
-  },
-  data() {
-    return {
-      dialog: false,
-      languages: [
-        { name: this.$t("settings.auto"), code: "auto" },
-        { name: "English", code: "en" },
-        { name: "中文", code: "zh" },
-      ],
-    };
-  },
-  methods: {
-    open() {
-      this.dialog = true;
-    },
-    onClose() {
-      this.dialog = false;
-      this.$emit("done");
-    },
-    ...mapMutations(["setCurrentLanguage"]),
-  },
-  computed: {
-    ...mapState(["lang"]),
-  },
+const { t: $t } = useI18n();
+const store = useStore();
+
+const props = defineProps(["open"]);
+const emit = defineEmits(["update:open", "done"]);
+
+const settings = [
+  ChatGPTBotSettings,
+  OpenAIAPIBotSettings,
+  BingChatBotSettings,
+  SparkBotSettings,
+  BardBotSettings,
+  MOSSBotSettings,
+  WenxinQianfanBotSettings,
+  GradioAppBotSettings,
+];
+
+const languages = ref([
+  { name: $t("settings.auto"), code: "auto" },
+  { name: "English", code: "en" },
+  { name: "中文", code: "zh" },
+]);
+
+const lang = computed(() => store.state.lang);
+
+const setCurrentLanguage = (lang) => {
+  store.commit("setCurrentLanguage", lang);
+};
+const closeDialog = () => {
+  emit("update:open", false);
+  emit("done");
 };
 </script>
+
+<style scoped>
+.section {
+  margin-top: 16px;
+  margin-bottom: 16px;
+  padding: 0 16px;
+}
+</style>


### PR DESCRIPTION
This pull request contains the following changes:

1. The composition API is more clear and easy to use. Try to change two modal components to use the composition API.
2. Avoid directly accessing component instances using component references. Instead, use states to control child components.
3. Add more space between setting sections.