### PR TITLE
Add a composable used to get the Matomo instance in SFC

### DIFF
--- a/src/composables/matomo.js
+++ b/src/composables/matomo.js
@@ -1,0 +1,36 @@
+import { ref, onUnmounted } from "vue";
+
+export function getMatomo() {
+  return window.Piwik.getAsyncTracker();
+}
+
+export function useMatomo() {
+  const matomo = ref(null);
+
+  if (window.Piwik) {
+    matomo.value = getMatomo();
+  } else {
+    const interval = 50;
+    const timeout = 3000;
+    const start = Date.now();
+
+    const timer = setInterval(() => {
+      if (window.Piwik) {
+        clearInterval(timer);
+        matomo.value = getMatomo();
+        return;
+      }
+
+      if (Date.now() - start > timeout) {
+        clearInterval(timer);
+        console.warn(`Matomo not loaded after waiting for ${timeout}ms`);
+      }
+    }, interval);
+
+    onUnmounted(() => {
+      clearInterval(timer);
+    });
+  }
+
+  return matomo;
+}


### PR DESCRIPTION
After exploring the code of the "vue-matoto", I found that it initializes the Matomo instance asynchronously. This prevents the Matomo instance from being accessible to components immediately after the app is mounted.

To make it work in SFC, a possible solution without touching the code of "vue-matomo" would be to create a composable called `useMatomo`. Within this function, create a ref of null, then start a timer to check if `window.Piwik` exists. Once `window.Piwik` becomes available, assign the value of `window.Piwik.getAsyncTracker()` to the ref. Finally, return the ref as the output of the function.

Then we can use Matomo in SFC as follows:

```javascript
const $matomo = useMatomo();

const onSomeCallback = () => {
  $matomo.value?.trackEvent();
}
```

This can be used to fix the problems in #72 