### PR TITLE
Fix update notification race condition

### DIFF
--- a/src/components/Notification/UpdateNotificationModal.vue
+++ b/src/components/Notification/UpdateNotificationModal.vue
@@ -27,14 +27,20 @@
 <script setup>
 import { ref } from "vue";
 import { compare } from 'compare-versions';
-const { shell } = window.require("electron");
+const { shell, ipcRenderer } = window.require("electron");
 
-const versions = JSON.parse(localStorage.getItem("chatall-versions"));
+let versions = undefined;
 const snackbar = ref(false);
-if (versions?.latest && versions?.current && compare(versions.latest, versions.current, '>')) {
-  if (!versions?.skip || compare(versions.latest, versions.skip, '>')) {
-    snackbar.value = true;
+ipcRenderer.on('version-saved', checkVersion);
+
+function checkVersion() {
+  versions = JSON.parse(localStorage.getItem("chatall-versions"));
+  if (versions?.latest && versions?.current && compare(versions.latest, versions.current, '>')) {
+    if (!versions?.skip || compare(versions.latest, versions.skip, '>')) {
+      snackbar.value = true;
+    }
   }
+  ipcRenderer.removeListener('version-saved', checkVersion);
 }
 
 function skip() {

--- a/src/update.js
+++ b/src/update.js
@@ -18,6 +18,7 @@ const saveLatestVersion = async (data) => {
         })
       );`;
     await localMainWindow.webContents.executeJavaScript(saveVersionScript);
+    localMainWindow.webContents.send('version-saved');
     autoUpdater.removeListener("error", getLatestVersionFromGithub);
   }
 };


### PR DESCRIPTION
There is a race condition where requesting the latest version from GitHub takes time in the main process, but the `UpdateNotificationModal` component has already been created in the renderer process.

This cause update notification only shows up after user launches the app for the second time when there is a new version available.

To fix this issue, I added code to emit an event on `version-saved` channel after the version is successfully saved.
And listen to the `version-saved` channel and trigger the `checkVersion` function in the `UpdateNotificationModal` component.

This can make sure the version checking only happens after the latest version is retrieved from GitHub. Sorry for the oversight that caused this issue.