### PR TITLE
add isAvailable checking for chatGPTBrowsingBot

### DIFF
--- a/src/bots/openai/ChatGPT4Bot.js
+++ b/src/bots/openai/ChatGPT4Bot.js
@@ -35,7 +35,10 @@ export default class ChatGPT4Bot extends ChatGPTBot {
     const isAvailable = await super.checkAvailability();
     this.constructor._isAvailable = reserved;
 
-    if (isAvailable) {
+    // 浏览器登陆状态
+    if (this.getClassname() == 'ChatGPTBrowsingBot') {
+      this.constructor._isAvailable = isAvailable;
+    }else if (isAvailable) {
       try {
         const headers = {
           "Content-Type": "application/json",


### PR DESCRIPTION
Describe the bug / 描述问题
点击ChatGPT (Web 浏览)，打开页面登录后回到主界面，该bot没有被选中。

Expected behavior / 期望行为
如果可以登陆就应该可以选择使用。代码中似乎存在继承问题，ChatGPTBrowsingBot继承了ChatGPT4Bot,但在调用checkAvailability的时候没有进行区分，导致程序会请求isPaidSubscriptionActive状态，如果只能登陆而不是付费用户（？）的情况下无法获取到正确的状态。可以通过以下方式进行区分（src/bots/openai/ChatGPT4Bot.js）：

reference: https://github.com/sunner/ChatALL/issues/174