### PR TITLE
Find on page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "vue-i18n": "^9.2.2",
         "vue-matomo": "^4.2.0",
         "vue3-markdown-it": "^1.0.10",
+        "vue3-shortkey": "^4.0.0",
         "vuetify": "^3.2.3",
         "vuex": "^4.1.0",
         "vuex-persist": "^3.1.3",
@@ -7784,6 +7785,11 @@
       "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/custom-event-polyfill": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
+      "integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
+    },
     "node_modules/cyclist": {
       "version": "1.0.2",
       "resolved": "https://registry.npmmirror.com/cyclist/-/cyclist-1.0.2.tgz",
@@ -8831,6 +8837,11 @@
       "version": "18.16.18",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-18.16.18.tgz",
       "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw=="
+    },
+    "node_modules/element-matches": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
+      "integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ=="
     },
     "node_modules/elliptic": {
       "version": "6.5.4",
@@ -20171,6 +20182,15 @@
       "dependencies": {
         "highlight.js": "^11.3.1",
         "lodash.flow": "^3.5.0"
+      }
+    },
+    "node_modules/vue3-shortkey": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/vue3-shortkey/-/vue3-shortkey-4.0.0.tgz",
+      "integrity": "sha512-pXb/K7aw3ViqzWL9jz/IL4wOk7M7FQ87ekYxk5J7uKTNEfOVBYtILGjvCBJD3/zEUipcLQJEg7TjE1xYnVYV/w==",
+      "dependencies": {
+        "custom-event-polyfill": "^1.0.7",
+        "element-matches": "^0.1.2"
       }
     },
     "node_modules/vuetify": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "vue-i18n": "^9.2.2",
     "vue-matomo": "^4.2.0",
     "vue3-markdown-it": "^1.0.10",
+    "vue3-shortkey": "^4.0.0",
     "vuetify": "^3.2.3",
     "vuex": "^4.1.0",
     "vuex-persist": "^3.1.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -51,6 +51,7 @@
           ></v-icon>
         </div>
       </div>
+      <FindModal></FindModal>
     </header>
 
     <main class="content">
@@ -81,6 +82,7 @@ import SettingsModal from "@/components/SettingsModal.vue";
 import ConfirmModal from "@/components/ConfirmModal.vue";
 import FooterBar from "@/components/Footer/FooterBar.vue";
 import UpdateNotification from "@/components/Notification/UpdateNotificationModal.vue";
+import FindModal from "@/components/FindModal.vue";
 
 // Styles
 import "@mdi/font/css/materialdesignicons.css";

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,8 @@
           <img
             src="@/assets/column-1.svg"
             @click="changeColumns(1)"
+            @shortkey="changeColumns(1)"
+            v-shortkey.once="['f1']"
             :class="{
               selected: columns === 1,
               'dark-png': store.state.theme === Theme.DARK,
@@ -20,6 +22,8 @@
           <img
             src="@/assets/column-2.svg"
             @click="changeColumns(2)"
+            @shortkey="changeColumns(2)"
+            v-shortkey.once="['f2']"
             :class="{
               selected: columns === 2,
               'dark-png': store.state.theme === Theme.DARK,
@@ -28,6 +32,8 @@
           <img
             src="@/assets/column-3.svg"
             @click="changeColumns(3)"
+            @shortkey="changeColumns(3)"
+            v-shortkey.once="['f3']"
             :class="{
               selected: columns === 3,
               'dark-png': store.state.theme === Theme.DARK,

--- a/src/components/FindModal.vue
+++ b/src/components/FindModal.vue
@@ -1,0 +1,136 @@
+<template>
+  <v-form
+    ref="formRef"
+    @submit.prevent="true"
+    v-shortkey.once="['ctrl', 'f']"
+    @shortkey="handleFindShortcut"
+    style="
+      position: absolute;
+      right: 0;
+      width: 400px;
+      min-width: 200px;
+      padding-top: 20px;
+    "
+  >
+    <v-text-field
+      @keydown.enter="() => find()"
+      @focus="$event.target.select()"
+      ref="findTextRef"
+      color="primary"
+      density="compact"
+      variant="solo"
+      :label="$t('find.find')"
+      single-line
+      :rules="[() => isMatch || $t('find.noMatches')]"
+      v-model="findTextModel"
+      v-show="isShowFindText"
+      prepend-inner-icon="mdi-magnify"
+    >
+      <template v-slot:append-inner>
+        <v-btn-group>
+          <v-btn
+            size="x-small"
+            icon="mdi-chevron-up"
+            @click="find(true)"
+          ></v-btn>
+          <v-btn
+            size="x-small"
+            icon="mdi-chevron-down"
+            @click="find(false)"
+          ></v-btn>
+        </v-btn-group>
+        <v-tooltip
+          :text="$t('find.matchCase')"
+          location="bottom"
+          v-model="isShowMatchCaseTooltip"
+        >
+          <template v-slot:activator="{ props }">
+            <v-btn-toggle v-model="matchCaseToggle">
+              <v-btn
+                :value="MATCH_CASE_VALUE"
+                v-bind="props"
+                size="x-small"
+                icon="mdi-format-letter-case"
+              ></v-btn>
+            </v-btn-toggle>
+          </template>
+        </v-tooltip>
+        <v-tooltip
+          :text="$t('find.wrapAround')"
+          location="bottom"
+          v-model="isShowWrapAroundTooltip"
+        >
+          <template v-slot:activator="{ props }">
+            <v-btn-toggle v-model="wrapAroundToggle">
+              <v-btn
+                :value="WRAP_AROUND_VALUE"
+                v-bind="props"
+                size="x-small"
+                icon="mdi-autorenew"
+              ></v-btn>
+            </v-btn-toggle>
+          </template>
+        </v-tooltip>
+        <v-btn-group>
+          <v-btn
+            size="x-small"
+            icon="mdi-close"
+            @click="closeFindTextField"
+          ></v-btn>
+        </v-btn-group>
+      </template>
+    </v-text-field>
+  </v-form>
+</template>
+
+<script setup>
+import { ref, nextTick } from "vue";
+
+const formRef = ref(null);
+
+const findTextRef = ref(null);
+const findTextModel = ref("");
+const isShowFindText = ref(false);
+
+const MATCH_CASE_VALUE = "case";
+const WRAP_AROUND_VALUE = "wrap";
+
+const matchCaseToggle = ref([]); // default disable match case
+const isShowMatchCaseTooltip = ref(false);
+
+const wrapAroundToggle = ref([WRAP_AROUND_VALUE]); // default enable wrap around
+const isShowWrapAroundTooltip = ref(false);
+
+const isMatch = ref(true);
+
+function handleFindShortcut() {
+  isShowFindText.value ? closeFindTextField() : showFindTextField();
+}
+
+function showFindTextField() {
+  isShowFindText.value = true;
+  nextTick(() => {
+    findTextRef.value.$el.querySelector("input").focus();
+  });
+}
+
+function closeFindTextField() {
+  isShowFindText.value = false;
+}
+
+function find(backward) {
+  isMatch.value = window.find(
+    findTextModel.value,
+    matchCaseToggle.value?.length,
+    backward,
+    wrapAroundToggle.value?.length,
+  );
+  formRef.value.validate();
+}
+</script>
+
+<style scoped>
+:deep() .v-field {
+    padding-right: 0;
+}
+</style>

--- a/src/components/Footer/FooterBar.vue
+++ b/src/components/Footer/FooterBar.vue
@@ -37,6 +37,8 @@
         :active="activeBots[bot.classname]"
         size="36"
         @click="toggleSelected(bot.instance)"
+        v-shortkey.once="['alt', `${index + 1}`]"
+        @shortkey="toggleSelected(bot.instance)" 
       />
       <BotsMenu :favBots="favBots" />
     </div>

--- a/src/components/Footer/FooterBar.vue
+++ b/src/components/Footer/FooterBar.vue
@@ -1,7 +1,11 @@
 <template>
-  <div class="footer">
+  <div class="footer"
+    v-shortkey.once="['alt', 'k']" 
+    @shortkey="focusPromptTextarea"
+  >
     <v-textarea
       v-model="prompt"
+      ref="promptTextArea"
       auto-grow
       max-rows="8.5"
       rows="1"
@@ -62,6 +66,7 @@ const store = useStore();
 const matomo = useMatomo();
 
 const confirmModal = ref(null);
+const promptTextArea = ref(null);
 
 const bots = ref(_bots.all);
 const activeBots = reactive({});
@@ -112,6 +117,10 @@ async function updateActiveBots() {
     activeBots[favBot.classname] =
       favBot.instance.isAvailable() && favBot.selected;
   }
+}
+
+function focusPromptTextarea() {
+  promptTextArea.value.$el.querySelector('textarea').focus()
 }
 
 // Send the prompt when the user presses enter and prevent the default behavior

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -141,5 +141,11 @@
     "downloadFromGitHub": "Download from GitHub",
     "skipThisVersion": "Skip this Version",
     "close": "Close"
+  },
+  "find": {
+    "find": "Find",
+    "noMatches": "No matches",
+    "matchCase": "Match case",
+    "wrapAround": "Wrap around"
   }
 }

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -141,5 +141,11 @@
     "downloadFromGitHub": "去 GitHub 下载",
     "skipThisVersion": "跳过此版本",
     "close": "关闭"
+  },
+  "find": {
+    "find": "查找",
+    "noMatches": "未找到结果",
+    "matchCase": "匹配大小写",
+    "wrapAround": "循环查找"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import { createVueI18nAdapter } from "vuetify/locale/adapters/vue-i18n";
 import { useI18n } from "vue-i18n";
 import "material-design-icons/iconfont/material-icons.css";
 import VueMatomo from "vue-matomo";
+import VueShortkey from 'vue3-shortkey';
 import { resolveTheme, applyTheme } from "./theme";
 
 // Vuetify
@@ -38,6 +39,7 @@ const vuetify = createVuetify({
           surface: "#FFFFFF",
           background: "#f3f3f3",
           "surface-variant": "#fff",
+          "on-surface-variant": "#212121",
           header: "#fff",
           prompt: "#95ec69",
           response: "#fff",
@@ -51,6 +53,7 @@ const vuetify = createVuetify({
           surface: "#292a2d",
           background: "#1a1a20",
           "surface-variant": "#131419",
+          "on-surface-variant": "#fff",
           header: "#292a2d",
           prompt: "#222329",
           response: "#131419",
@@ -74,6 +77,7 @@ createApp(App)
   .use(i18n)
   .use(store)
   .use(vuetify)
+  .use(VueShortkey)
   .use(VueMatomo, {
     // Configure your matomo server and site by providing
     host: "https://matomo.chatall.ai/",


### PR DESCRIPTION
### Added "Find on Page" functionality.

#### I tried to make the feature same experience as browser, but below is the limitation for now:
- I tried to use the <kbd>Esc</kbd> key to close the "Find on Page", but this shortcut is already used to close the bot list menu and the settings page. So using <kbd>Ctrl</kbd> + <kbd>F</kbd> to open and close it instead.
- I tried to use <kbd>Shift</kbd> + <kbd>Enter</kbd> to search backward, but the code (`@keydown.shift.enter="() => search(true)"`) doesn't work properly. It works the first time you press it, but subsequent presses don't trigger the search method. So, need to click the button instead.

#### I have also added shortcuts for some common actions. Feel free to suggest better alternatives.

- To switch to one, two or three column layout, press <kbd>F1</kbd>, <kbd>F2</kbd>, <kbd>F3</kbd> respectively
- To toggle selected bot to chat with, press <kbd>Alt</kbd> + <kbd>1</kbd>, <kbd>Alt</kbd> + <kbd>2</kbd>, <kbd>Alt</kbd> + <kbd>3</kbd>, until <kbd>Alt</kbd> + <kbd>9</kbd> according to user favorite bot sequence.
- To focus prompt textarea, press <kbd>Alt</kbd> + <kbd>K</kbd>.
- To toggle find on page, press <kbd>Ctrl</kbd> + <kbd>F</kbd>.