### PR TITLE
Shortcut guide

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,7 @@
         </div>
         <div>
           <v-icon
-            id="find-btn"
+            :id="SHORTCUT_FIND.elementId"
             class="cursor-pointer"
             color="primary"
             icon="mdi-magnify"
@@ -46,6 +46,16 @@
             size="x-large"
             @click="openSettingsModal()"
           ></v-icon>
+          <v-icon
+            v-shortkey.once="SHORTCUT_SHORTCUT_GUIDE.key"
+            @shortkey="toggleShortcutGuide"
+            :id="SHORTCUT_SHORTCUT_GUIDE.elementId"
+            class="cursor-pointer"
+            color="primary"
+            icon="mdi-help"
+            size="x-large"
+            @click="toggleShortcutGuide()"
+          ></v-icon>
         </div>
       </div>
       <FindModal ref="findRef"></FindModal>
@@ -61,6 +71,10 @@
     <SettingsModal v-model:open="isSettingsOpen" />
     <ConfirmModal ref="confirmModal" />
     <UpdateNotification></UpdateNotification>
+    <ShortcutGuide
+      ref="shortcutGuideRef"
+      v-model:open="isShortcutGuideOpen"
+    ></ShortcutGuide>
   </div>
 </template>
 
@@ -71,6 +85,10 @@ import { useTheme } from "vuetify";
 import { useStore } from "vuex";
 import { v4 as uuidv4 } from "uuid";
 import { applyTheme, resolveTheme, Theme } from "./theme";
+import {
+  SHORTCUT_FIND,
+  SHORTCUT_SHORTCUT_GUIDE,
+} from "./components/ShortcutGuide/shortcut.const";
 
 import i18n from "./i18n";
 
@@ -81,6 +99,7 @@ import ConfirmModal from "@/components/ConfirmModal.vue";
 import FooterBar from "@/components/Footer/FooterBar.vue";
 import UpdateNotification from "@/components/Notification/UpdateNotificationModal.vue";
 import FindModal from "@/components/FindModal.vue";
+import ShortcutGuide from "@/components/ShortcutGuide/ShortcutGuide.vue";
 
 // Styles
 import "@mdi/font/css/materialdesignicons.css";
@@ -99,6 +118,8 @@ ipcRenderer.on("on-updated-system-theme", onUpdatedSystemTheme);
 
 const confirmModal = ref(null);
 const findRef = ref(null);
+const shortcutGuideRef = ref(null);
+const isShortcutGuideOpen = ref(false);
 const isSettingsOpen = ref(false);
 
 const columns = computed(() => store.state.columns);
@@ -107,15 +128,20 @@ const changeColumns = (columns) => store.commit("changeColumns", columns);
 const setUuid = (uuid) => store.commit("setUuid", uuid);
 
 async function openSettingsModal() {
-  if (isSettingsOpen.value) { // click too fast
+  if (isSettingsOpen.value) {
+    // click too fast
     isSettingsOpen.value = false;
     await nextTick();
-  } 
+  }
   isSettingsOpen.value = true;
 }
 
 function openFind() {
   findRef.value.showFindTextField();
+}
+
+function toggleShortcutGuide() {
+  shortcutGuideRef.value.toggleShortcutGuide();
 }
 
 async function clearMessages() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,6 +43,9 @@
             @click="clearMessages()"
           ></v-icon>
           <v-icon
+            v-shortkey.once="SHORTCUT_SETTINGS.key"
+            @shortkey="openSettingsModal"
+            :id="SHORTCUT_SETTINGS.elementId"
             class="cursor-pointer"
             color="primary"
             icon="mdi-cog"
@@ -90,6 +93,7 @@ import { v4 as uuidv4 } from "uuid";
 import { applyTheme, resolveTheme, Theme } from "./theme";
 import {
   SHORTCUT_FIND,
+  SHORTCUT_SETTINGS,
   SHORTCUT_SHORTCUT_GUIDE,
   SHORTCUT_CLEAR_MESSAGES,
 } from "./components/ShortcutGuide/shortcut.const";

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,6 +33,9 @@
             @click="openFind()"
           ></v-icon>
           <v-icon
+            v-shortkey.once="SHORTCUT_CLEAR_MESSAGES.key"
+            @shortkey="clearMessages"
+            :id="SHORTCUT_CLEAR_MESSAGES.elementId"
             class="cursor-pointer"
             color="primary"
             icon="mdi-broom"
@@ -88,6 +91,7 @@ import { applyTheme, resolveTheme, Theme } from "./theme";
 import {
   SHORTCUT_FIND,
   SHORTCUT_SHORTCUT_GUIDE,
+  SHORTCUT_CLEAR_MESSAGES,
 } from "./components/ShortcutGuide/shortcut.const";
 
 import i18n from "./i18n";

--- a/src/components/FindModal.vue
+++ b/src/components/FindModal.vue
@@ -2,7 +2,7 @@
   <v-form
     ref="formRef"
     @submit.prevent="true"
-    v-shortkey.once="['ctrl', 'f']"
+    v-shortkey.once="SHORTCUT_FIND.key"
     @shortkey="handleFindShortcut"
     style="
       position: absolute;
@@ -86,6 +86,7 @@
 
 <script setup>
 import { ref, nextTick } from "vue";
+import { SHORTCUT_FIND } from "./ShortcutGuide/shortcut.const";
 
 const formRef = ref(null);
 

--- a/src/components/FindModal.vue
+++ b/src/components/FindModal.vue
@@ -15,6 +15,7 @@
     <v-text-field
       id="find-text-field"
       @keydown.enter="() => find()"
+      @keydown.esc="closeFindTextField"
       @focus="$event.target.select()"
       ref="findTextRef"
       color="primary"

--- a/src/components/Footer/FooterBar.vue
+++ b/src/components/Footer/FooterBar.vue
@@ -2,13 +2,13 @@
   <div
     class="footer"
     v-shortkey.once="{
-      focusPromptTextarea: ['ctrl', 'k'],
-      toggleBotsMenu: ['ctrl', 'tab'],
+      focusPromptTextarea: SHORTCUT_PROMPT_TEXTAREA.key,
+      toggleBotsMenu: SHORTCUT_BOTS_MENU.key,
     }"
     @shortkey="handleShortcut"
   >
     <v-textarea
-      id="prompt-textarea"
+      :id="SHORTCUT_PROMPT_TEXTAREA.elementId"
       v-model="prompt"
       ref="promptTextArea"
       auto-grow
@@ -46,7 +46,11 @@
         v-shortkey.once="['ctrl', `${index + 1}`]"
         @shortkey="toggleSelected(bot.instance)"
       />
-      <BotsMenu id="bots-menu-btn" ref="botsMenuRef" :favBots="favBots" />
+      <BotsMenu
+        :id="SHORTCUT_BOTS_MENU.elementId"
+        ref="botsMenuRef"
+        :favBots="favBots"
+      />
     </div>
     <MakeAvailableModal v-model:open="isMakeAvailableOpen" :bot="clickedBot" />
     <ConfirmModal ref="confirmModal" />
@@ -67,6 +71,10 @@ import BotsMenu from "./BotsMenu.vue";
 import { useMatomo } from "@/composables/matomo";
 
 import _bots from "@/bots";
+import {
+  SHORTCUT_PROMPT_TEXTAREA,
+  SHORTCUT_BOTS_MENU,
+} from "./../ShortcutGuide/shortcut.const";
 
 const { ipcRenderer } = window.require("electron");
 

--- a/src/components/ShortcutGuide/ShortcutGuide.vue
+++ b/src/components/ShortcutGuide/ShortcutGuide.vue
@@ -1,0 +1,114 @@
+<template>
+  <v-overlay
+    :scrim="true"
+    :model-value="props.open"
+    v-on:after-leave="closeShortcutGuide"
+    @click="closeShortcutGuide"
+  >
+    <div
+      style="
+        position: absolute;
+        top: 0;
+        left: 15px;
+        width: 100vw;
+        height: 100vh;
+      "
+    >
+      <div
+        ref="shortcutGuideContentRef"
+        style="position: relative"
+        class="markdown-body"
+      ></div>
+    </div>
+  </v-overlay>
+</template>
+
+<script setup>
+const props = defineProps(["open"]);
+const emit = defineEmits(["update:open", "done"]);
+
+import { ref } from "vue";
+import { onUpdated } from "vue";
+import { SHORTCUT_LIST } from "./shortcut.const";
+
+const shortcutGuideContentRef = ref(null);
+
+onUpdated(async () => {
+  if (!props.open) {
+    return;
+  }
+  addWindowResizeListener();
+  SHORTCUT_LIST.forEach((shortcut) => {
+    const shortcutElement = document.getElementById(shortcut.elementId);
+    if (!shortcutElement) {
+      return;
+    }
+    const position = shortcutElement.getBoundingClientRect();
+    const div = document.createElement("div");
+    div.classList.add("shortcut-label");
+    div.style.top = `${position.top + (shortcut.offset?.top ?? 0)}px`;
+    if (shortcut.alignHorizontallyCenter) {
+      div.style.left = `${
+        position.left + position.width / 2 + (shortcut.offset?.left ?? 0)
+      }px`;
+    } else {
+      div.style.left = `${position.left + (shortcut.offset?.left ?? 0)}px`;
+    }
+    div.innerHTML = getShortcutLabelHTML(shortcut.key);
+    div.style.flexDirection = shortcut.flexDirection;
+    shortcutGuideContentRef.value.appendChild(div);
+  });
+});
+
+function getShortcutLabelHTML(keys) {
+  return keys.map(kbd).join("<span>+</span>");
+}
+
+function kbd(text) {
+  return `<kbd>${capitalizeFirstLetter(text)}</kbd>`;
+}
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function addWindowResizeListener() {
+  window.addEventListener("resize", closeShortcutGuide);
+}
+
+const toggleShortcutGuide = () => {
+  if (props.open) {
+    closeShortcutGuide();
+  } else {
+    openShortcutGuide();
+  }
+};
+
+const closeShortcutGuide = () => {
+  window.removeEventListener("resize", closeShortcutGuide);
+  emit("update:open", false);
+  emit("done");
+};
+
+const openShortcutGuide = () => {
+  addWindowResizeListener();
+  emit("update:open", true);
+};
+
+defineExpose({
+  toggleShortcutGuide,
+});
+</script>
+<style scoped>
+:deep() .shortcut-label {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+:deep() span {
+  line-height: 1rem;
+  color: rgb(var(--v-theme-font));
+}
+</style>

--- a/src/components/ShortcutGuide/shortcut.const.js
+++ b/src/components/ShortcutGuide/shortcut.const.js
@@ -1,0 +1,138 @@
+export const SHORTCUT_PROMPT_TEXTAREA = {
+  elementId: "prompt-textarea",
+  key: ["ctrl", "k"],
+  offset: {
+    top: 10,
+  },
+  alignHorizontallyCenter: true,
+};
+
+export const SHORTCUT_FIND = {
+  elementId: "find-btn",
+  key: ["ctrl", "f"],
+  offset: {
+    top: 40,
+  },
+  flexDirection: "column",
+};
+
+export const SHORTCUT_SHORTCUT_GUIDE = {
+  elementId: "shortcut-guide-btn",
+  key: ["ctrl", "/"],
+  offset: {
+    top: 40,
+  },
+  flexDirection: "column",
+};
+
+export const SHORTCUT_BOTS_MENU = {
+  elementId: "bots-menu-btn",
+  key: ["ctrl", "tab"],
+  offset: {
+    top: -70,
+  },
+  flexDirection: "column",
+};
+
+export const SHORTCUT_LIST = [
+  SHORTCUT_FIND,
+  SHORTCUT_BOTS_MENU,
+  SHORTCUT_SHORTCUT_GUIDE,
+  SHORTCUT_PROMPT_TEXTAREA,
+  {
+    elementId: "column-1",
+    key: ["f1"],
+    offset: {
+      top: 30,
+      left: -5,
+    },
+  },
+  {
+    elementId: "column-2",
+    key: ["f2"],
+    offset: {
+      top: 30,
+      left: -5,
+    },
+  },
+  {
+    elementId: "column-3",
+    key: ["f3"],
+    offset: {
+      top: 30,
+      left: -5,
+    },
+  },
+  {
+    elementId: "fav-bot-1",
+    key: ["ctrl", "1"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-2",
+    key: ["ctrl", "2"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-3",
+    key: ["ctrl", "3"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-4",
+    key: ["ctrl", "4"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-5",
+    key: ["ctrl", "5"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-6",
+    key: ["ctrl", "6"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-7",
+    key: ["ctrl", "7"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-8",
+    key: ["ctrl", "8"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+  {
+    elementId: "fav-bot-9",
+    key: ["ctrl", "9"],
+    offset: {
+      top: -70,
+    },
+    flexDirection: "column",
+  },
+];

--- a/src/components/ShortcutGuide/shortcut.const.js
+++ b/src/components/ShortcutGuide/shortcut.const.js
@@ -16,6 +16,15 @@ export const SHORTCUT_FIND = {
   flexDirection: "column",
 };
 
+export const SHORTCUT_CLEAR_MESSAGES = {
+  elementId: "clear-messages-btn",
+  key: ["ctrl", "e"],
+  offset: {
+    top: 40,
+  },
+  flexDirection: "column",
+};
+
 export const SHORTCUT_SHORTCUT_GUIDE = {
   elementId: "shortcut-guide-btn",
   key: ["ctrl", "/"],
@@ -38,6 +47,7 @@ export const SHORTCUT_LIST = [
   SHORTCUT_FIND,
   SHORTCUT_BOTS_MENU,
   SHORTCUT_SHORTCUT_GUIDE,
+  SHORTCUT_CLEAR_MESSAGES,
   SHORTCUT_PROMPT_TEXTAREA,
   {
     elementId: "column-1",

--- a/src/components/ShortcutGuide/shortcut.const.js
+++ b/src/components/ShortcutGuide/shortcut.const.js
@@ -25,6 +25,15 @@ export const SHORTCUT_CLEAR_MESSAGES = {
   flexDirection: "column",
 };
 
+export const SHORTCUT_SETTINGS = {
+  elementId: "settings-btn",
+  key: ["ctrl", ","],
+  offset: {
+    top: 40,
+  },
+  flexDirection: "column",
+};
+
 export const SHORTCUT_SHORTCUT_GUIDE = {
   elementId: "shortcut-guide-btn",
   key: ["ctrl", "/"],
@@ -45,6 +54,7 @@ export const SHORTCUT_BOTS_MENU = {
 
 export const SHORTCUT_LIST = [
   SHORTCUT_FIND,
+  SHORTCUT_SETTINGS,
   SHORTCUT_BOTS_MENU,
   SHORTCUT_SHORTCUT_GUIDE,
   SHORTCUT_CLEAR_MESSAGES,


### PR DESCRIPTION
Add a shortcut guide and some refactoring.

Add shortcut guide and find icon on the top bar.

Add Ctrl + Tab to open bots menu

Comment:

I tried to move the shortcut label using absolute position, but their position changes with different window sizes.

I have been trying for hours to find the reason but with no luck. Fortunately, I found using canvas to draw SVG can keeps the shortcut label position consistent regardless of the window size.

Limitation:
Due to draw with the canvas, the image is not sharp, I not sure how to increase the resolution yet.

The favorite bot shortcut label is not aligned when the window is small.


![image](https://github.com/sunner/ChatALL/assets/26683979/c35ae7f8-b735-49ef-84a8-f9ec8797213d)
