### PR TITLE
Add Resend Button

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -1,0 +1,273 @@
+<template>
+  <v-card
+    ref="root"
+    :class="['message', 'response', isHighlighted ? 'highlight-border' : '']"
+    :loading="isAllDone ? false : 'primary'"
+  >
+    <v-card-title class="title">
+      <img :src="botLogo" alt="Bot Icon" />
+      {{ botFullname }}
+      <v-spacer></v-spacer>
+      <v-btn
+        flat
+        icon
+        size="x-small"
+        v-if="isShowPagingButton"
+        @click="carouselModel = Math.max(carouselModel - 1, 0)"
+        :disabled="carouselModel === 0"
+      >
+        <v-icon>mdi-menu-left</v-icon>
+      </v-btn>
+      <v-btn
+        flat
+        icon
+        size="x-small"
+        v-if="isShowPagingButton"
+        @click="carouselModel = Math.min(carouselModel + 1, maxPage)"
+        :disabled="carouselModel === maxPage"
+      >
+        <v-icon>mdi-menu-right</v-icon>
+      </v-btn>
+      <v-btn
+        flat
+        icon
+        size="x-small"
+        v-if="isShowResendButton"
+        @click="resendPrompt(messages[0])"
+      >
+        <v-icon>mdi-refresh</v-icon>
+      </v-btn>
+      <v-btn
+        flat
+        size="x-small"
+        icon
+        @click="toggleHighlight"
+        :color="isHighlighted ? 'primary' : ''"
+      >
+        <v-icon>mdi-lightbulb-on-outline</v-icon>
+      </v-btn>
+      <v-btn flat size="x-small" icon @click="copyToClipboard">
+        <v-icon>mdi-content-copy</v-icon>
+      </v-btn>
+      <v-btn flat size="x-small" icon @click="hide">
+        <v-icon>mdi-delete</v-icon>
+      </v-btn>
+    </v-card-title>
+    <Markdown
+      v-if="props.messages.length === 1"
+      class="markdown-body"
+      :breaks="true"
+      :html="messages[0].format === 'html'"
+      :source="messages[0].content"
+      @click="handleClick"
+    />
+    <v-carousel
+      v-else
+      hide-delimiter-background
+      :hide-delimiters="true"
+      height="auto"
+      :show-arrows="false"
+      v-model="carouselModel"
+    >
+      <v-carousel-item v-for="(message, i) in messages" :key="i">
+        <Markdown
+          class="markdown-body"
+          :breaks="true"
+          :html="message.format === 'html'"
+          :source="message.content"
+          @click="handleClick"
+        />
+      </v-carousel-item>
+    </v-carousel>
+  </v-card>
+  <ConfirmModal ref="confirmModal" />
+</template>
+
+<script setup>
+import { onMounted, ref, watch, computed } from "vue";
+import { useStore } from "vuex";
+import i18n from "@/i18n";
+import Markdown from "vue3-markdown-it";
+import { useMatomo } from "@/composables/matomo";
+import ConfirmModal from "@/components/ConfirmModal.vue";
+import bots from "@/bots";
+
+const props = defineProps({
+  messages: {
+    type: Array,
+    required: true,
+  },
+  columns: {
+    type: Number,
+    required: true,
+  },
+});
+
+const emits = defineEmits(["update-message"]);
+
+const matomo = useMatomo();
+const store = useStore();
+
+const root = ref();
+const maxPage = computed(() => props.messages.length - 1);
+const carouselModel = ref(maxPage.value);
+const confirmModal = ref(null);
+
+const botLogo = computed(() => {
+  const bot = bots.getBotByClassName(props.messages[0].className);
+  return bot ? bot.getLogo() : "";
+});
+
+const botFullname = computed(() => {
+  const bot = bots.getBotByClassName(props.messages[0].className);
+  return bot ? bot.getFullname() : "";
+});
+
+const isHighlighted = computed(() => props.messages.some((m) => m.highlight));
+const isAllDone = computed(() => {
+  return !props.messages.some((m) => !m.done);
+});
+const isShowResendButton = computed(() => {
+  return (
+    isAllDone.value &&
+    messageBotIsSelected() &&
+    props.messages[0].promptId &&
+    store.getters.currentChat.latestPromptId &&
+    store.getters.currentChat.latestPromptId === props.messages[0].promptId
+  );
+});
+const isShowPagingButton = computed(() => props.messages.length > 1);
+
+watch(
+  () => props.columns,
+  () => {
+    root.value.$el.style.setProperty("--columns", props.columns);
+  },
+);
+
+onMounted(() => {
+  root.value.$el.style.setProperty("--columns", props.columns);
+});
+
+function copyToClipboard() {
+  let content = props.messages[carouselModel.value].content;
+  if (props.messages[carouselModel.value].format === "html") {
+    content = content.replace(/<[^>]*>?/gm, "");
+  }
+  navigator.clipboard.writeText(content);
+  matomo.value?.trackEvent("vote", "copy", props.messages[0].className, 1);
+}
+
+function toggleHighlight() {
+  emits("update-message", props.messages[carouselModel.value].index, {
+    highlight: !props.messages[carouselModel.value].highlight,
+  });
+  matomo.value?.trackEvent(
+    "vote",
+    "highlight",
+    props.messages[carouselModel.value].className,
+    props.messages[carouselModel.value].highlight ? -1 : 1,
+  );
+}
+
+async function hide() {
+  const result = await confirmModal.value.showModal(
+    i18n.global.t("modal.confirmHide"),
+  );
+  if (result) {
+    emits("update-message", props.messages[0].index, { hide: true });
+    matomo.value?.trackEvent("vote", "hide", props.messages[0].className, 1);
+  }
+}
+
+function handleClick(event) {
+  const target = event.target;
+  if (target.tagName !== "A" && target.parentElement.tagName !== "A") {
+    return;
+  }
+  if (target.target === "innerWindow") {
+    // Open in Electron inner window
+    return;
+  }
+  // Open in external browser
+  event.preventDefault();
+  const electron = window.require("electron");
+  const url = target.href || target.parentElement.href;
+  electron.shell.openExternal(url);
+}
+
+function resendPrompt(responseMessage) {
+  if (!responseMessage.promptId) {
+    return;
+  }
+  const promptMessage = store.getters.currentChat.messages.find(
+    (m) => m.id === responseMessage.promptId && m.type === "prompt",
+  );
+  if (promptMessage) {
+    const botInstance = bots.getBotByClassName(responseMessage.className);
+    store.dispatch("sendPrompt", {
+      prompt: promptMessage.content,
+      bots: [botInstance],
+      promptId: responseMessage.promptId,
+    });
+  } else {
+    // show not found
+  }
+}
+
+function messageBotIsSelected() {
+  var favBot = store.getters.currentChat.favBots.find(
+    (b) => b.classname === props.messages[0].className,
+  );
+  return favBot?.selected;
+}
+</script>
+
+<style scoped>
+.markdown-body{
+    background-color: rgb(var(--v-theme-response));
+    font-family: inherit;
+  }
+  
+  .message {
+      border-radius: 8px;
+      padding: 16px;
+      word-wrap: break-word;
+      text-align: left;
+  }
+  
+  .highlight-border {
+      box-shadow: 0 0 0 2px rgba(var(--v-theme-primary), 1);
+  }
+  
+  .prompt {
+      background-color: rgb(var(--v-theme-prompt));
+      width: fit-content;
+      grid-column: 1 / span var(--columns);
+  }
+  
+  .prompt pre {
+    white-space: pre-wrap; 
+    font-family: inherit;
+  }
+  
+  .response {
+      background-color: rgb(var(--v-theme-response));
+      width: 100%;
+      grid-column: auto / span 1;
+  }
+  
+  .title {
+      display: flex;
+      align-items: center;
+      font-size: 1rem;
+      padding: 0;
+      margin-bottom: 8px;
+  }
+  
+  .title img {
+      width: 20px;
+      height: 20px;
+      margin-right: 4px;
+  }
+</style>

--- a/src/components/Messages/ChatResponses.vue
+++ b/src/components/Messages/ChatResponses.vue
@@ -1,0 +1,38 @@
+<template>
+  <template v-for="(grouped, index) in groupedResponses" :key="index">
+    <chat-response
+      :columns="columns"
+      :messages="grouped"
+      @update-message="props.updateMessage"
+    ></chat-response>
+  </template>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import ChatResponse from "./ChatResponse.vue";
+
+const props = defineProps({
+  responses: {
+    type: Array,
+    default: () => [],
+  },
+  columns: {
+    type: Number,
+    required: true,
+  },
+  updateMessage: {
+    type: Function,
+  },
+});
+
+const groupedResponses = computed(() => {
+  // group by bot class name
+  // group responses' from same bot in an array to populate to v-carousel
+  return props.responses.reduce(function (r, a) {
+    r[a.className] = r[a.className] || [];
+    r[a.className].push(a);
+    return r;
+  }, Object.create(null));
+});
+</script>


### PR DESCRIPTION
The LLM may not work due to a session expiration or the need to re-login.

Added refresh button to allow users to resend a prompt to the LLM without having to copy, paste, and press Enter.

This would also allow the LLM's response to appear near user prompt, so users don't have to scroll up and down across duplicated prompt and compare answers.

---

Update the way of messages render to support multiple responses for same chatbot for a prompt.
1. When the message type is a prompt, render as usual and clear the `responses` array
2. When the message type is a response:
- first will push current message to `responses` array.
- If the next message after current message is prompt type, it means we pass in `responses` array and render `chat-responses`.
- If not, just adding response to `responses` array until a prompt is hit.

**this is the method I can think of, because the current messages array mix with prompt and response type, and without id link to each other.

Added a resend button, page left and right button.
- Always show the last page.

Resend button
- Only allow for the latest prompt, to ensure the messages in storage are in order.
- Only allow for the selected/toggled bot. If the bot is turned off, the button will not be shown.
- Only allow when the response has a `promptId`, so that we can determine the content that needs to be resent.

Added `id` when add prompt and `promptId` field when adding response message to storage. So that when clicking resends button, we can get the prompt content for resend.

https://github.com/sunner/ChatALL/assets/26683979/2722a377-ef3f-4b48-933b-d649c6b7d7f1

