### PR TITLE
Fix overflow-y is hidden in v-carousel-item

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -224,6 +224,10 @@ function messageBotIsSelected() {
 </script>
 
 <style scoped>
+:deep() .v-responsive__content {
+  overflow: auto;
+}
+
 .markdown-body{
     background-color: rgb(var(--v-theme-response));
     font-family: inherit;


### PR DESCRIPTION
Found that after resending, the code block and markdown overflow-y is hidden in v-carousel-item