### PR TITLE
Move left and right arrow button to the left side

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -7,7 +7,6 @@
     <v-card-title class="title">
       <img :src="botLogo" alt="Bot Icon" />
       {{ botFullname }}
-      <v-spacer></v-spacer>
       <v-btn
         flat
         icon
@@ -15,6 +14,7 @@
         v-if="isShowPagingButton"
         @click="carouselModel = Math.max(carouselModel - 1, 0)"
         :disabled="carouselModel === 0"
+        style="margin-left: .5rem"
       >
         <v-icon>mdi-menu-left</v-icon>
       </v-btn>
@@ -28,6 +28,7 @@
       >
         <v-icon>mdi-menu-right</v-icon>
       </v-btn>
+      <v-spacer></v-spacer>
       <v-btn
         flat
         icon


### PR DESCRIPTION
To prevent accidentally click resend button.

When the user clicks the resend button, it will be hidden until the chat bot completes its response.

While the bot is responding and the user is clicking the right arrow to check the previous message, there is a possibility that the chat bot completes its response, causing user to accidentally click resend button again, which might incur costs for some bots.

I arranged the left and right buttons to the left side to separate them from the other buttons, also for better aesthetics?