### PR TITLE
Use index to get the message to resend

### DIFF
--- a/src/components/Messages/ChatMessages.vue
+++ b/src/components/Messages/ChatMessages.vue
@@ -6,7 +6,7 @@
     >
       <template v-for="(message, index) in filteredMessages" :key="index">
         <!-- Check if the current message is a prompt
-          If true, render <chat-message> component and set responses array empty -->
+          If true, render <chat-prompt> component and set responses array empty -->
         <chat-prompt
           v-if="checkIsMessagePromptTypeAndEmptyResponsesIfTrue(message)"
           :columns="columns"

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -14,7 +14,7 @@
         v-if="isShowPagingButton"
         @click="carouselModel = Math.max(carouselModel - 1, 0)"
         :disabled="carouselModel === 0"
-        style="margin-left: .5rem"
+        style="margin-left: 0.5rem"
       >
         <v-icon>mdi-menu-left</v-icon>
       </v-btn>
@@ -132,9 +132,10 @@ const isShowResendButton = computed(() => {
   return (
     isAllDone.value &&
     messageBotIsSelected() &&
-    props.messages[0].promptId &&
-    store.getters.currentChat.latestPromptId &&
-    store.getters.currentChat.latestPromptId === props.messages[0].promptId
+    props.messages[0].promptIndex &&
+    store.getters.currentChat.latestPromptIndex &&
+    store.getters.currentChat.latestPromptIndex ===
+      props.messages[0].promptIndex
   );
 });
 const isShowPagingButton = computed(() => props.messages.length > 1);
@@ -198,18 +199,17 @@ function handleClick(event) {
 }
 
 function resendPrompt(responseMessage) {
-  if (!responseMessage.promptId) {
+  if (!responseMessage.promptIndex) {
     return;
   }
-  const promptMessage = store.getters.currentChat.messages.find(
-    (m) => m.id === responseMessage.promptId && m.type === "prompt",
-  );
+  const promptMessage =
+    store.getters.currentChat.messages[responseMessage.promptIndex];
   if (promptMessage) {
     const botInstance = bots.getBotByClassName(responseMessage.className);
     store.dispatch("sendPrompt", {
       prompt: promptMessage.content,
       bots: [botInstance],
-      promptId: responseMessage.promptId,
+      promptIndex: responseMessage.promptIndex,
     });
   } else {
     // show not found

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,7 +2,6 @@ import { createStore } from "vuex";
 import VuexPersist from "vuex-persist";
 import i18n from "@/i18n";
 import messagesPersist from "./messagesPersist";
-import { v4 as uuidv4 } from "uuid";
 
 const getMatomo = function () {
   return window.Piwik.getAsyncTracker();
@@ -144,13 +143,9 @@ export default createStore({
     setGradio(state, values) {
       state.gradio = { ...state.gradio, ...values };
     },
-    addMessage(state, message) {
+    setLatestPromptIndex(state, promptIndex) {
       const currentChat = state.chats[state.currentChatIndex];
-      currentChat.messages.push(message);
-    },
-    setLatestPromptId(state, id) {
-      const currentChat = state.chats[state.currentChatIndex];
-      currentChat.latestPromptId = id;
+      currentChat.latestPromptIndex = promptIndex;
     },
     updateMessage(state, { indexes, message }) {
       const { chatIndex, messageIndex } = indexes;
@@ -208,19 +203,22 @@ export default createStore({
     },
   },
   actions: {
-    sendPrompt({ commit, state, dispatch }, { prompt, bots, promptId }) {
-      const id = promptId ? promptId : uuidv4();
-      if (!promptId) {
-        // if promptId not found, not a resend
-        commit("addMessage", {
+    sendPrompt({ commit, state, dispatch }, { prompt, bots, promptIndex }) {
+      const currentChat = state.chats[state.currentChatIndex];
+      if (!promptIndex) {
+        // if promptIndex not found, not resend, push to messages array
+        const promptMessage = {
           type: "prompt",
           content: prompt,
           done: true,
           hide: false,
-          id: id,
-        });
+        };
+        // add message
+        const index = currentChat.messages.push(promptMessage);
+        promptMessage.index = index - 1;
+        promptIndex = promptMessage.index;
       }
-      commit("setLatestPromptId", id); // to keep track of the latest prompt for hiding old prompt's resend button
+      commit("setLatestPromptIndex", promptIndex); // to keep track of the latest prompt index for hiding old prompt's resend button
 
       for (const bot of bots) {
         const message = {
@@ -232,11 +230,10 @@ export default createStore({
           highlight: false,
           hide: false,
           className: bot.getClassname(),
-          promptId: id,
+          promptIndex: promptIndex,
         };
 
         // workaround for tracking message position
-        const currentChat = state.chats[state.currentChatIndex];
         message.index = currentChat.messages.push(message) - 1;
 
         bot.sendPrompt(


### PR DESCRIPTION
I found that it is actually not necessary to use a UUID as an ID for prompt messages.

Update to use index in `message` array.

Just like response message index:
https://github.com/sunner/ChatALL/blob/c1f58470b8100655082bb969c63d7cdcb6e3b422/src/store/index.js#L239-L240

So, we can direct access the message using index for resend.

Instead of using `find()`, which is slower:

https://github.com/sunner/ChatALL/blob/c1f58470b8100655082bb969c63d7cdcb6e3b422/src/components/Messages/ChatResponse.vue#L204-L206