### PR TITLE
Minimize window before show to fix dark mode bot login flicker for Windows

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -122,6 +122,8 @@ function createNewWindow(url, userAgent = "") {
   const newWin = new BrowserWindow({
     width: 800,
     height: 600,
+    show: false,
+    backgroundColor: nativeTheme.shouldUseDarkColors ? "#1a1a20" : "#fff",
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,
@@ -132,7 +134,9 @@ function createNewWindow(url, userAgent = "") {
   if (userAgent) {
     newWin.webContents.setUserAgent(userAgent);
   }
+  if (process.platform !== "darwin") newWin.minimize();
   newWin.loadURL(url);
+  newWin.show();
 
   newWin.on("close", async (e) => {
     e.preventDefault(); // Prevent the window from closing


### PR DESCRIPTION
~~Show window when [ready-to-show event](https://www.electronjs.org/docs/latest/api/browser-window#using-the-ready-to-show-event) emitted to prevent flickering in the create new window for bot login.~~

Minimize window before show to fix dark mode bot login flicker #300
