### PR TITLE
Add chat thread

### DIFF
--- a/src/components/FindModal.vue
+++ b/src/components/FindModal.vue
@@ -113,9 +113,7 @@ function handleFindShortcut() {
 
 function showFindTextField() {
   isShowFindText.value = true;
-  nextTick(() => {
-    findTextRef.value.$el.querySelector("input").focus();
-  });
+  nextTick().then(findTextRef.value.focus);
 }
 
 function closeFindTextField() {

--- a/src/components/Footer/FooterBar.vue
+++ b/src/components/Footer/FooterBar.vue
@@ -137,7 +137,7 @@ async function updateActiveBots() {
 }
 
 function focusPromptTextarea() {
-  promptTextArea.value.$el.querySelector("textarea").focus();
+  promptTextArea.value.focus();
 }
 
 function toggleBotsMenu() {

--- a/src/components/Messages/ChatMessages.vue
+++ b/src/components/Messages/ChatMessages.vue
@@ -11,7 +11,6 @@
           v-if="checkIsMessagePromptTypeAndEmptyResponsesIfTrue(message)"
           :columns="columns"
           :message="message"
-          @update-message="updateMessage"
         ></chat-prompt>
         <template v-else>
           <!-- If current message is response, push current message to responses array.

--- a/src/components/Messages/ChatPrompt.vue
+++ b/src/components/Messages/ChatPrompt.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-card ref="root" class="message prompt">
+  <v-card
+    ref="root"
+    class="message prompt"
+    :class="props.isThread ? 'thread-prompt' : ''"
+  >
     <pre>{{ props.message.content }}</pre>
   </v-card>
 </template>
@@ -17,6 +21,10 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  isThread: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 watch(
@@ -33,20 +41,26 @@ onMounted(() => {
 
 <style scoped>
 .message {
-    border-radius: 8px;
-    padding: 16px;
-    word-wrap: break-word;
-    text-align: left;
+  border-radius: 8px;
+  padding: 16px;
+  word-wrap: break-word;
+  text-align: left;
 }
 
 .prompt {
-    background-color: rgb(var(--v-theme-prompt));
-    width: fit-content;
-    grid-column: 1 / span var(--columns);
+  background-color: rgb(var(--v-theme-prompt));
+  width: fit-content;
+  grid-column: 1 / span var(--columns);
 }
 
 .prompt pre {
-  white-space: pre-wrap; 
+  white-space: pre-wrap;
   font-family: inherit;
+}
+
+.thread-prompt {
+  width: 100%;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 </style>

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -99,7 +99,7 @@
           flat
           icon
           size="x-small"
-          v-if="isShowResendButton"
+          :style="{ visibility: isShowResendButton ? 'visible' : 'hidden' }"
           @click="resendPrompt(messages[0])"
         >
           <v-icon>mdi-refresh</v-icon>
@@ -108,7 +108,7 @@
           flat
           icon
           size="x-small"
-          v-if="isShowReplyButton"
+          :style="{ visibility: isShowReplyButton ? 'visible' : 'hidden' }"
           :color="isShowReplyTextField ? 'primary' : ''"
           @click="toggleReplyButton"
         >

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -1,8 +1,13 @@
 <template>
   <v-card
     ref="root"
-    :class="['message', 'response', isHighlighted ? 'highlight-border' : '']"
+    :class="[
+      'message',
+      isHighlighted ? 'highlight-border' : '',
+      props.isThread ? 'response-thread' : 'response',
+    ]"
     :loading="isAllDone ? false : 'primary'"
+    :flat="props.isThread"
   >
     <v-card-title class="title">
       <img :src="botLogo" alt="Bot Icon" />
@@ -54,14 +59,23 @@
         <v-icon>mdi-delete</v-icon>
       </v-btn>
     </v-card-title>
-    <Markdown
-      v-if="props.messages.length === 1"
-      class="markdown-body"
-      :breaks="true"
-      :html="messages[0].format === 'html'"
-      :source="messages[0].content"
-      @click="handleClick"
-    />
+    <template v-if="props.messages.length === 1">
+      <Markdown
+        class="markdown-body"
+        :breaks="true"
+        :html="messages[0].format === 'html'"
+        :source="messages[0].content"
+        @click="handleClick"
+      />
+      <template v-if="!props.isThread && messages[0].threadIndex !== undefined">
+        <!-- if the repsonse is not a thread and there is value in message.threadIndex, means thread existed for this response
+            we pass in threadIndex into <chat-thread> to render based on the threadIndex -->
+        <chat-thread
+          :threadIndex="messages[0].threadIndex"
+          :updateThreadMessage="updateThreadMessage"
+        ></chat-thread>
+      </template>
+    </template>
     <v-carousel
       v-else
       hide-delimiter-background
@@ -78,8 +92,41 @@
           :source="message.content"
           @click="handleClick"
         />
+        <template v-if="!props.isThread && message.threadIndex !== undefined">
+          <!-- if the repsonse is not a thread and there is value in message.threadIndex, means thread existed for this response
+          we pass in threadIndex into <chat-thread> to render based on the threadIndex -->
+          <chat-thread
+            :threadIndex="message.threadIndex"
+            :updateThreadMessage="updateThreadMessage"
+          ></chat-thread>
+        </template>
       </v-carousel-item>
     </v-carousel>
+    <div
+      v-if="isShowThreadTextField"
+      style="display: flex; align-items: flex-end; margin-top: 1rem"
+    >
+      <v-textarea
+        style="padding-right: 0.5rem"
+        v-model="promptRef"
+        auto-grow
+        max-rows="8.5"
+        rows="1"
+        density="compact"
+        hide-details
+        variant="solo"
+        :placeholder="`${$t('footer.sendPrompt')} ${botFullname}`"
+        @keydown="filterEnterKey"
+      ></v-textarea>
+      <v-btn
+        :disabled="promptRef.trim() === ''"
+        color="primary"
+        size="small"
+        @click="sendPromptToBot"
+      >
+        <v-icon>mdi-send</v-icon>
+      </v-btn>
+    </div>
   </v-card>
   <ConfirmModal ref="confirmModal" />
 </template>
@@ -91,6 +138,7 @@ import i18n from "@/i18n";
 import Markdown from "vue3-markdown-it";
 import { useMatomo } from "@/composables/matomo";
 import ConfirmModal from "@/components/ConfirmModal.vue";
+import ChatThread from "./ChatThread.vue";
 import bots from "@/bots";
 
 const props = defineProps({
@@ -102,14 +150,23 @@ const props = defineProps({
     type: Number,
     required: true,
   },
+  threadIndex: {
+    type: Number,
+    required: false,
+  },
+  isThread: {
+    type: Boolean,
+    default: false,
+  },
 });
 
-const emits = defineEmits(["update-message"]);
+const emits = defineEmits(["update-message", "update-thread-message"]);
 
 const matomo = useMatomo();
 const store = useStore();
 
 const root = ref();
+const promptRef = ref("");
 const maxPage = computed(() => props.messages.length - 1);
 const carouselModel = ref(maxPage.value);
 const confirmModal = ref(null);
@@ -124,21 +181,107 @@ const botFullname = computed(() => {
   return bot ? bot.getFullname() : "";
 });
 
-const isHighlighted = computed(() => props.messages.some((m) => m.highlight));
-const isAllDone = computed(() => {
-  return !props.messages.some((m) => !m.done);
-});
-const isShowResendButton = computed(() => {
-  return (
-    isAllDone.value &&
-    messageBotIsSelected() &&
-    props.messages[0].promptIndex &&
-    store.getters.currentChat.latestPromptIndex &&
+const isHighlighted = computed(() => props.messages.some((m) => m.highlight)); // if any message is hightlighted, return true
+const isAllDone = computed(() => !props.messages.some((m) => !m.done)); // if any message is not done, return false
+const isLatestPrompt = computed(
+  // if the current message response to user latest prompt, return true
+  // this flag is used to determine whether to hide Resend button, hide it when is not latest prompt
+  // to ensure the prompt and response in messages array is in correct order
+  () =>
+    props.messages[0].promptIndex !== undefined &&
+    store.getters.currentChat.latestPromptIndex !== undefined &&
     store.getters.currentChat.latestPromptIndex ===
-      props.messages[0].promptIndex
+      props.messages[0].promptIndex,
+);
+
+const isLatestPromptForThread = computed(() => {
+  if (props.isThread) {
+    // if the current thread is response latest prompt, return true
+    // this flag is used to determine whether to hide Resend button in thread, hide it when is not latest prompt
+    // to ensure the prompt and response in messages array is in correct order
+    const responseIndex =
+      store.getters.currentChat.threads[props.threadIndex].responseIndex; // get responseIndex, from current thread
+    const threadPromptIndex =
+      store.getters.currentChat.messages[responseIndex].promptIndex; // using responseIndex to get response from messages, and in the repsonse we can retrieve promptIndex
+    return (
+      threadPromptIndex !== undefined &&
+      store.getters.currentChat.latestPromptIndex !== undefined &&
+      store.getters.currentChat.latestPromptIndex === threadPromptIndex
+    );
+  }
+  return false;
+});
+const isShowThreadTextField = computed(() => {
+  return (
+    // show the thread text field when all conditions met
+    !props.isThread && // if current response is not a thread,
+    isAllDone.value && // if all response done,
+    messageBotIsSelected() && // if responding bot selected,
+    isLatestPrompt.value && // if current response is a response to latest prompt,
+    carouselModel.value === maxPage.value // if current response is on last page,
   );
 });
+const isSomeResponsesHasThread = computed(() =>
+  // if some responses contain threadIndex, return true
+  props.messages.some((m) => m.threadIndex !== undefined),
+);
+
+const isShowResendButton = computed(() => {
+  // show the resend button when all conditions met
+  if (props.isThread) {
+    return (
+      isAllDone.value && // if all response done
+      messageBotIsSelected() && // if responding bot selected
+      props.messages[0].promptIndex !== undefined && // if current threads is a response to latest prompt
+      store.getters.currentChat.threads[props.threadIndex].latestPromptIndex !==
+        undefined &&
+      store.getters.currentChat.threads[props.threadIndex].latestPromptIndex ===
+        props.messages[0].promptIndex &&
+      isLatestPromptForThread.value
+    );
+  } else {
+    return (
+      !isSomeResponsesHasThread.value && // if all responses don't have thread
+      isAllDone.value && // if all response done
+      messageBotIsSelected() && // if responding bot selected
+      isLatestPrompt.value // if current response is a response to latest prompt
+    );
+  }
+});
 const isShowPagingButton = computed(() => props.messages.length > 1);
+
+// Send the prompt when the user presses enter and prevent the default behavior
+// But if the shift, ctrl, alt, or meta keys are pressed, do as default
+function filterEnterKey(event) {
+  if (
+    event.keyCode == 13 &&
+    !event.shiftKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey
+  ) {
+    event.preventDefault();
+    sendPromptToBot();
+  }
+}
+
+function sendPromptToBot() {
+  if (promptRef.value.trim() === "") return;
+
+  const botInstance = bots.getBotByClassName(props.messages[0].className);
+
+  store.dispatch("sendPromptInThread", {
+    responseIndex: props.messages[carouselModel.value].index,
+    threadIndex: props.messages[carouselModel.value].threadIndex,
+    prompt: promptRef.value,
+    bot: botInstance,
+  });
+
+  // Clear the textarea after sending the prompt
+  promptRef.value = "";
+
+  matomo.value?.trackEvent("prompt", "send", "Active bots count", 1);
+}
 
 watch(
   () => props.columns,
@@ -146,6 +289,17 @@ watch(
     root.value.$el.style.setProperty("--columns", props.columns);
   },
 );
+
+const updateThreadMessage = (threadIndex, messageIndex, values) => {
+  store.dispatch("updateThreadMessage", {
+    indexes: {
+      chatIndex: store.state.currentChatIndex,
+      messageIndex,
+      threadIndex,
+    },
+    message: values,
+  });
+};
 
 onMounted(() => {
   root.value.$el.style.setProperty("--columns", props.columns);
@@ -161,9 +315,20 @@ function copyToClipboard() {
 }
 
 function toggleHighlight() {
-  emits("update-message", props.messages[carouselModel.value].index, {
-    highlight: !props.messages[carouselModel.value].highlight,
-  });
+  if (props.isThread) {
+    emits(
+      "update-thread-message",
+      props.threadIndex,
+      props.messages[carouselModel.value].index,
+      {
+        highlight: !props.messages[carouselModel.value].highlight,
+      },
+    );
+  } else {
+    emits("update-message", props.messages[carouselModel.value].index, {
+      highlight: !props.messages[carouselModel.value].highlight,
+    });
+  }
   matomo.value?.trackEvent(
     "vote",
     "highlight",
@@ -177,7 +342,18 @@ async function hide() {
     i18n.global.t("modal.confirmHide"),
   );
   if (result) {
-    emits("update-message", props.messages[0].index, { hide: true });
+    if (props.isThread) {
+      emits(
+        "update-thread-message",
+        props.threadIndex,
+        props.messages[carouselModel.value].index,
+        { hide: true },
+      );
+    } else {
+      emits("update-message", props.messages[carouselModel.value].index, {
+        hide: true,
+      });
+    }
     matomo.value?.trackEvent("vote", "hide", props.messages[0].className, 1);
   }
 }
@@ -199,20 +375,39 @@ function handleClick(event) {
 }
 
 function resendPrompt(responseMessage) {
-  if (!responseMessage.promptIndex) {
+  if (responseMessage.promptIndex === undefined) {
     return;
   }
-  const promptMessage =
-    store.getters.currentChat.messages[responseMessage.promptIndex];
-  if (promptMessage) {
-    const botInstance = bots.getBotByClassName(responseMessage.className);
-    store.dispatch("sendPrompt", {
-      prompt: promptMessage.content,
-      bots: [botInstance],
-      promptIndex: responseMessage.promptIndex,
-    });
+  if (props.isThread) {
+    const promptMessage =
+      store.getters.currentChat.threads[props.threadIndex].messages[
+        responseMessage.promptIndex
+      ];
+    if (promptMessage) {
+      const botInstance = bots.getBotByClassName(responseMessage.className);
+      store.dispatch("sendPromptInThread", {
+        prompt: promptMessage.content,
+        bot: botInstance,
+        promptIndex: responseMessage.promptIndex,
+        responseIndex: responseMessage.index,
+        threadIndex: props.threadIndex,
+      });
+    } else {
+      // show not found
+    }
   } else {
-    // show not found
+    const promptMessage =
+      store.getters.currentChat.messages[responseMessage.promptIndex];
+    if (promptMessage) {
+      const botInstance = bots.getBotByClassName(responseMessage.className);
+      store.dispatch("sendPrompt", {
+        prompt: promptMessage.content,
+        bots: [botInstance],
+        promptIndex: responseMessage.promptIndex,
+      });
+    } else {
+      // show not found
+    }
   }
 }
 
@@ -229,50 +424,58 @@ function messageBotIsSelected() {
   overflow: auto;
 }
 
-.markdown-body{
-    background-color: rgb(var(--v-theme-response));
-    font-family: inherit;
-  }
-  
-  .message {
-      border-radius: 8px;
-      padding: 16px;
-      word-wrap: break-word;
-      text-align: left;
-  }
-  
-  .highlight-border {
-      box-shadow: 0 0 0 2px rgba(var(--v-theme-primary), 1);
-  }
-  
-  .prompt {
-      background-color: rgb(var(--v-theme-prompt));
-      width: fit-content;
-      grid-column: 1 / span var(--columns);
-  }
-  
-  .prompt pre {
-    white-space: pre-wrap; 
-    font-family: inherit;
-  }
-  
-  .response {
-      background-color: rgb(var(--v-theme-response));
-      width: 100%;
-      grid-column: auto / span 1;
-  }
-  
-  .title {
-      display: flex;
-      align-items: center;
-      font-size: 1rem;
-      padding: 0;
-      margin-bottom: 8px;
-  }
-  
-  .title img {
-      width: 20px;
-      height: 20px;
-      margin-right: 4px;
-  }
+.markdown-body {
+  background-color: rgb(var(--v-theme-response));
+  font-family: inherit;
+}
+
+.message {
+  border-radius: 8px;
+  padding: 16px;
+  word-wrap: break-word;
+  text-align: left;
+}
+
+.highlight-border {
+  box-shadow: 0 0 0 2px rgba(var(--v-theme-primary), 1);
+}
+
+.prompt {
+  background-color: rgb(var(--v-theme-prompt));
+  width: fit-content;
+  grid-column: 1 / span var(--columns);
+}
+
+.prompt pre {
+  white-space: pre-wrap;
+  font-family: inherit;
+}
+
+.response {
+  background-color: rgb(var(--v-theme-response));
+  width: 100%;
+  grid-column: auto / span 1;
+}
+
+.response-thread {
+  background-color: rgb(var(--v-theme-response));
+  width: 98%;
+  grid-column: auto / span 1;
+  margin-left: .2rem;
+  margin-bottom: .2rem;
+}
+
+.title {
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+  padding: 0;
+  margin-bottom: 8px;
+}
+
+.title img {
+  width: 20px;
+  height: 20px;
+  margin-right: 4px;
+}
 </style>

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -12,37 +12,7 @@
     <v-card-title class="title">
       <img :src="botLogo" alt="Bot Icon" />
       {{ botFullname }}
-      <v-btn
-        flat
-        icon
-        size="x-small"
-        v-if="isShowPagingButton"
-        @click="carouselModel = Math.max(carouselModel - 1, 0)"
-        :disabled="carouselModel === 0"
-        style="margin-left: 0.5rem"
-      >
-        <v-icon>mdi-menu-left</v-icon>
-      </v-btn>
-      <v-btn
-        flat
-        icon
-        size="x-small"
-        v-if="isShowPagingButton"
-        @click="carouselModel = Math.min(carouselModel + 1, maxPage)"
-        :disabled="carouselModel === maxPage"
-      >
-        <v-icon>mdi-menu-right</v-icon>
-      </v-btn>
       <v-spacer></v-spacer>
-      <v-btn
-        flat
-        icon
-        size="x-small"
-        v-if="isShowResendButton"
-        @click="resendPrompt(messages[0])"
-      >
-        <v-icon>mdi-refresh</v-icon>
-      </v-btn>
       <v-btn
         flat
         size="x-small"
@@ -107,8 +77,37 @@
         <v-spacer></v-spacer>
         <v-btn
           flat
-          size="x-small"
           icon
+          size="x-small"
+          v-if="isShowPagingButton"
+          @click="carouselModel = Math.max(carouselModel - 1, 0)"
+          :disabled="carouselModel === 0"
+        >
+          <v-icon>mdi-menu-left</v-icon>
+        </v-btn>
+        <v-btn
+          flat
+          icon
+          size="x-small"
+          v-if="isShowPagingButton"
+          @click="carouselModel = Math.min(carouselModel + 1, maxPage)"
+          :disabled="carouselModel === maxPage"
+        >
+          <v-icon>mdi-menu-right</v-icon>
+        </v-btn>
+        <v-btn
+          flat
+          icon
+          size="x-small"
+          v-if="isShowResendButton"
+          @click="resendPrompt(messages[0])"
+        >
+          <v-icon>mdi-refresh</v-icon>
+        </v-btn>
+        <v-btn
+          flat
+          icon
+          size="x-small"
           v-if="isShowReplyButton"
           :color="isShowReplyTextField ? 'primary' : ''"
           @click="toggleReplyButton"

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -234,8 +234,7 @@ const isShowReplyButton = computed(() => {
     !props.isThread && // if current response is not a thread,
     isAllDone.value && // if all response done,
     messageBotIsSelected() && // if responding bot selected,
-    isLatestPrompt.value && // if current response is a response to latest prompt,
-    carouselModel.value === maxPage.value // if current response is on last page,
+    isLatestPrompt.value // if current response is a response to latest prompt,
   );
 });
 const isSomeResponsesHasThread = computed(() =>
@@ -288,11 +287,13 @@ function sendPromptToBot() {
   const botInstance = bots.getBotByClassName(props.messages[0].className);
 
   store.dispatch("sendPromptInThread", {
-    responseIndex: props.messages[carouselModel.value].index,
+    responseIndex: props.messages[maxPage.value].index, // always send prompt in thread to last page
     threadIndex: props.messages[carouselModel.value].threadIndex,
     prompt: replyModel.value,
     bot: botInstance,
   });
+
+  carouselModel.value = maxPage.value; // move to last page
 
   // Clear the textarea after sending the prompt
   replyModel.value = "";

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -197,7 +197,7 @@ const botFullname = computed(() => {
   return bot ? bot.getFullname() : "";
 });
 
-const isHighlighted = computed(() => props.messages.some((m) => m.highlight)); // if any message is hightlighted, return true
+const isHighlighted = computed(() => props.messages[maxPage.value].highlight); // if last response is hightlighted, return true
 const isAllDone = computed(() => !props.messages.some((m) => !m.done)); // if any message is not done, return false
 const isLatestPrompt = computed(
   // if the current message response to user latest prompt, return true
@@ -337,14 +337,14 @@ function toggleHighlight() {
     emits(
       "update-thread-message",
       props.threadIndex,
-      props.messages[carouselModel.value].index,
+      props.messages[maxPage.value].index,
       {
-        highlight: !props.messages[carouselModel.value].highlight,
+        highlight: !props.messages[maxPage.value].highlight, // only update last response highlight
       },
     );
   } else {
-    emits("update-message", props.messages[carouselModel.value].index, {
-      highlight: !props.messages[carouselModel.value].highlight,
+    emits("update-message", props.messages[maxPage.value].index, {
+      highlight: !props.messages[maxPage.value].highlight,
     });
   }
   matomo.value?.trackEvent(

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -72,7 +72,7 @@
         </template>
       </v-carousel-item>
     </v-carousel>
-    <v-card class="response" style="padding: 0">
+    <v-card class="response" style="padding: 0; margin-top: 0.5rem" flat>
       <v-card-title style="display: flex; padding: 0">
         <v-spacer></v-spacer>
         <v-btn
@@ -120,7 +120,11 @@
         style="display: flex; align-items: flex-end; margin-top: 1rem"
       >
         <v-textarea
-          style="padding-right: 0.5rem"
+          style="
+            padding-left: 0.1rem;
+            padding-right: 0.5rem;
+            padding-bottom: 0.1rem;
+          "
           ref="replyRef"
           v-model="replyModel"
           auto-grow
@@ -484,10 +488,9 @@ function toggleReplyButton() {
 
 .response-thread {
   background-color: rgb(var(--v-theme-response));
-  width: 98%;
+  width: 99%;
   grid-column: auto / span 1;
-  margin-left: .2rem;
-  margin-bottom: .2rem;
+  margin: auto;
 }
 
 .title {

--- a/src/components/Messages/ChatResponses.vue
+++ b/src/components/Messages/ChatResponses.vue
@@ -3,7 +3,10 @@
     <chat-response
       :columns="columns"
       :messages="grouped"
+      :isThread="props.isThread"
+      :threadIndex="props.threadIndex"
       @update-message="props.updateMessage"
+      @update-thread-message="props.updateThreadMessage"
     ></chat-response>
   </template>
 </template>
@@ -23,6 +26,17 @@ const props = defineProps({
   },
   updateMessage: {
     type: Function,
+  },
+  updateThreadMessage: {
+    type: Function,
+  },
+  threadIndex: {
+    type: Number,
+    required: false,
+  },
+  isThread: {
+    type: Boolean,
+    default: false,
   },
 });
 

--- a/src/components/Messages/ChatThread.vue
+++ b/src/components/Messages/ChatThread.vue
@@ -1,0 +1,64 @@
+<template>
+  <template v-for="(message, index) in messages" :key="index">
+    <chat-prompt
+      v-if="checkIsMessagePromptTypeAndEmptyResponsesIfTrue(message)"
+      :message="message"
+      :columns="1"
+      :isThread="true"
+    ></chat-prompt>
+    <template v-else>
+      <chat-responses
+        v-if="pushResponseAndCheckIsNextMessagePromptType(index, message)"
+        :columns="1"
+        :responses="responses"
+        :threadIndex="props.threadIndex"
+        :isThread="true"
+        :updateThreadMessage="props.updateThreadMessage"
+      ></chat-responses>
+    </template>
+  </template>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+import { useStore } from "vuex";
+import ChatPrompt from "@/components/Messages/ChatPrompt.vue";
+import ChatResponses from "@/components/Messages/ChatResponses.vue";
+
+const store = useStore();
+
+const props = defineProps({
+  threadIndex: {
+    type: Number,
+    required: true,
+  },
+  updateThreadMessage: {
+    type: Function,
+  },
+});
+
+const thread = ref(store.getters.currentChat.threads[props.threadIndex]);
+const messages = computed(() => {
+  return (thread.value ? thread.value.messages : []).filter(
+    (message) => !message.hide,
+  );
+});
+
+let responses = []; // this array store a prompt responses in a thread
+function checkIsMessagePromptTypeAndEmptyResponsesIfTrue(message) {
+  if (message.type === "prompt") {
+    responses = []; // clear responses for next prompt's responses
+    return true;
+  }
+  return false;
+}
+
+function pushResponseAndCheckIsNextMessagePromptType(index, response) {
+  const nextIndex = index + 1;
+  if (!response.hide) responses.push(response);
+  if (nextIndex >= messages.value.length) {
+    return true; // allow last element
+  }
+  return messages.value[nextIndex].type === "prompt";
+}
+</script>


### PR DESCRIPTION
Added chat thread feature to allow users to chat with individual chatbots.

Currently, we could only chat concurrently with all of the selected bots.

Sometimes, users may want to reply to a specific bot after it responds to their prompt.

However, they had to deselect or turn off other bots to do that.

With this chat thread feature, users can easily switch between different bots and have more focused conversations.

![image](https://github.com/sunner/ChatALL/assets/26683979/57ab793f-4fad-4c18-a5c1-7dc4faff3e01)

---
---
---

To store the thread messages, I have added a new array called `threads`.

The `threads` array is similar to the current `messages` array, but it has an additional property called `responseIndex`. This property indicates which response message the thread was started from.

For better understanding, here's an illustration of the data structure, the index references. 

![image](https://github.com/sunner/ChatALL/assets/26683979/e6a9ca26-7619-423a-8632-0be7f9922260)
[diagram.drawio.zip](https://github.com/sunner/ChatALL/files/11895090/messages.data.structure.diagramm.zip)

I have added a `ChatThread` component and updated many parts of the code to support thread messages. Refer to the component tree diagram. the `ChatThread` component, which is similar to the `ChatMessages` component and renders `ChatPrompt` and `ChatResponses`.

![image](https://github.com/sunner/ChatALL/assets/26683979/df80c9dc-83df-4f06-9237-5b8a47827042)


### Scenarios tested

1. chat
2. chat, resend
3. chat, create thread
4. chat, resend, chat in thread
5. chat, chat in thread, resend in thread
6. chat, chat in thread, resend in thread, chat in thread
7. chat, chat in thread, resend in thread, chat in thread, resend in thread
8. highlight response and response in thread
9. copy response and response in thread
10. run the feature with existing data structure
11. first time launch
12. codeblock and markdown table overflow-y