### PR TITLE
fix：Bug#308  

### DIFF
--- a/src/bots/openai/OpenAIAPIBot.js
+++ b/src/bots/openai/OpenAIAPIBot.js
@@ -15,6 +15,9 @@ export default class OpenAIAPIBot extends LangChainBot {
       this.constructor._isAvailable = false;
     } else {
       const chatModel = new ChatOpenAI({
+        configuration: {
+          basePath: store.state.openaiApi.alterUrl ? store.state.openaiApi.alterUrl : "",
+        },
         openAIApiKey: store.state.openaiApi.apiKey,
         modelName: this.constructor._model ? this.constructor._model : "",
         temperature: store.state.openaiApi.temperature,

--- a/src/components/BotSettings/OpenAIAPIBotSettings.vue
+++ b/src/components/BotSettings/OpenAIAPIBotSettings.vue
@@ -51,7 +51,7 @@
       v-model="openaiApi.alterUrl"
       outlined
       dense
-      placeholder="https://your.proxy.com/v1/chat/completions"
+      placeholder="https://your.proxy.com/v1"
       @update:model-value="setOpenaiApi({ alterUrl: $event })"
     ></v-text-field>
   </v-list-item>


### PR DESCRIPTION
In Langchain.js, OpenAI does not support alterUrl. Therefore, the configuration for alterUrl, store, and i18n has been removed.