### PR TITLE
fix: skip reporting events if matomo is not loaded

### DIFF
--- a/src/composables/matomo.js
+++ b/src/composables/matomo.js
@@ -1,23 +1,25 @@
 import { ref, onUnmounted } from "vue";
 
 export function getMatomo() {
-  return window.Piwik.getAsyncTracker();
+  return window.Piwik?.getAsyncTracker();
 }
 
 export function useMatomo() {
   const matomo = ref(null);
 
-  if (window.Piwik) {
-    matomo.value = getMatomo();
+  const instance = getMatomo();
+  if (instance) {
+    matomo.value = instance;
   } else {
     const interval = 50;
     const timeout = 10000;
     const start = Date.now();
 
     const timer = setInterval(() => {
-      if (window.Piwik) {
+      const instance = getMatomo();
+      if (instance) {
         clearInterval(timer);
-        matomo.value = getMatomo();
+        matomo.value = instance;
         return;
       }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,10 +2,7 @@ import { createStore } from "vuex";
 import VuexPersist from "vuex-persist";
 import i18n from "@/i18n";
 import messagesPersist from "./messagesPersist";
-
-const getMatomo = function () {
-  return window.Piwik.getAsyncTracker();
-};
+import { getMatomo } from "@/composables/matomo";
 
 // 初始化 VuexPersist 实例
 const vuexPersist = new VuexPersist({
@@ -243,7 +240,7 @@ export default createStore({
           { chatIndex: state.currentChatIndex, messageIndex: message.index },
         );
 
-        getMatomo().trackEvent(
+        getMatomo()?.trackEvent(
           "prompt",
           "sendTo",
           bot.getClassname(),
@@ -262,7 +259,7 @@ export default createStore({
       const chat = state.chats[i];
       const message = { ...chat.messages[indexes.messageIndex], ...values };
       if (values.done) {
-        getMatomo().trackEvent(
+        getMatomo()?.trackEvent(
           "prompt",
           "received",
           message.className,


### PR DESCRIPTION
Previously, the getMatomo function didn't check the existence of Piwik. An exception prevents the UI from updating if the matomo is not loading properly.

This pull request fixes the problem by skipping reporting events if matomo is not loaded. And as the getMatomo function is already declared in the `src/composables/matomo.js`, I removed the duplicated one in the `src/store/index.js`.