### PR TITLE
Allow to sort favorite bots order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "highlight.js": "^11.8.0",
         "langchain": "0.0.97",
         "material-design-icons": "^3.0.1",
+        "sortablejs": "^1.15.0",
         "update-electron-app": "^2.0.1",
         "uuid": "^9.0.0",
         "vue": "^3.3.4",
@@ -17390,6 +17391,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
+      "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "highlight.js": "^11.8.0",
     "langchain": "0.0.97",
     "material-design-icons": "^3.0.1",
+    "sortablejs": "^1.15.0",
     "update-electron-app": "^2.0.1",
     "uuid": "^9.0.0",
     "vue": "^3.3.4",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -100,6 +100,15 @@ export default createStore({
       if (bot) bot.selected = selected;
       else currentChat.favBots.push({ classname: botClassname, selected });
     },
+    setFavBotOrder(state, newOrder) {
+      const currentChat = state.chats[state.currentChatIndex];
+      newOrder.forEach((botClassname, order) => {
+        const bot = currentChat.favBots.find(
+          (bot) => bot.classname === botClassname,
+        );
+        if (bot) bot.order = order;
+      });
+    },
     addFavoriteBot(state, botClassname) {
       const currentChat = state.chats[state.currentChatIndex];
       const favBots = currentChat.favBots;


### PR DESCRIPTION
Allow users to sort their favorite bots by dragging them.

The shortkey Ctrl + 1 to 9 to toggle the bots will be updated according to the user's order.

![sort](https://github.com/sunner/ChatALL/assets/26683979/9f0ffeaa-e314-46bf-a63b-2a21fac68105)
