### PR TITLE
Update chat title to first 30 characters of user first prompt

### DIFF
--- a/src/components/ChatDrawer/ChatDrawerItem.vue
+++ b/src/components/ChatDrawer/ChatDrawerItem.vue
@@ -106,7 +106,10 @@ function editChat() {
 }
 
 function confirmEdit() {
-  store.commit("editChatTitle", chatTitleEditModel.value);
+  store.commit("editChatTitle", {
+    title: chatTitleEditModel.value,
+    isEditedByUser: true,
+  });
   isEditMode.value = false;
 }
 

--- a/src/components/Footer/FooterBar.vue
+++ b/src/components/Footer/FooterBar.vue
@@ -197,10 +197,13 @@ function sendPromptToBots() {
 
   if (toBots.length === 0) return;
 
-  store.dispatch("sendPrompt", {
-    prompt: prompt.value,
-    bots: toBots,
-  });
+  const isFirstPrompt = store.getters.currentChat.messages.length === 0;
+  store
+    .dispatch("sendPrompt", {
+      prompt: prompt.value,
+      bots: toBots,
+    })
+    .then(() => updateChatTitleWithFirstPrompt(isFirstPrompt));
 
   // Clear the textarea after sending the prompt
   prompt.value = "";
@@ -295,6 +298,15 @@ function initializeSortable() {
   favBotLogosRef.value.addEventListener("drop", () => {
     isDropOnFavBotBar = true;
   });
+}
+
+function updateChatTitleWithFirstPrompt(isFirstPrompt) {
+  if (isFirstPrompt) {
+    // if this is first prompt, update chat title to first 30 characters of user prompt
+    store.commit("editChatTitle", {
+      title: store.getters.currentChat.messages[0].content.substring(0, 30),
+    });
+  }
 }
 
 defineExpose({

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -257,8 +257,16 @@ export default createStore({
     hideChat(state) {
       state.chats[state.currentChatIndex].hide = true;
     },
-    editChatTitle(state, title) {
-      state.chats[state.currentChatIndex].title = title;
+    editChatTitle(state, { title, isEditedByUser = false }) {
+      if (isEditedByUser) {
+        state.chats[state.currentChatIndex].title = title;
+        state.chats[state.currentChatIndex].isTitleUserEdited = true;  
+      } else {
+        if (!state.chats[state.currentChatIndex].isTitleUserEdited) {
+          // if user has not edit title before, set title
+          state.chats[state.currentChatIndex].title = title;
+        } // else do not overwrite user title
+      }
     },
     setIsChatDrawerOpen(state, isChatDrawerOpen) {
       state.isChatDrawerOpen = isChatDrawerOpen;


### PR DESCRIPTION
Add feature to update chat title to the first 30 characters of the user's first prompt, after the user sends their first prompt in a chat.

This can allow users to conveniently know what the chat is about, compare to the current default of always showing "New Chat".

Add `isTitleUserEdited` to check if user edited the chat title manually, if true, will not update chat title automatically.

I have tested that 30 characters should be enough to cover all languages to fill up the chat drawer width.

Let me know if 30 characters are too much / less or any other suggestions.

![image_2023_07_07T09_17_18_526Z](https://github.com/sunner/ChatALL/assets/26683979/4337d8e3-ef72-4f95-b34d-afd42b7c25eb)
