### PR TITLE
Make bot settings tabs scrollable

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -5,78 +5,80 @@
     :scrim="false"
     transition="dialog-bottom-transition"
   >
-    <v-card>
-      <v-toolbar dark color="primary">
-        <v-toolbar-title>{{ $t("settings.title") }}</v-toolbar-title>
-        <v-spacer></v-spacer>
+    <v-card class="overflow-hidden">
+      <div class="d-flex flex-column h-screen">
+        <v-toolbar height="100px" dark color="primary">
+          <v-toolbar-title>{{ $t("settings.title") }}</v-toolbar-title>
+          <v-spacer></v-spacer>
 
-        <v-btn icon dark @click="closeDialog">
-          <v-icon>mdi-close</v-icon>
-        </v-btn>
-      </v-toolbar>
-      <v-row>
-        <v-col cols="2">
-          <v-tabs v-model="tab" direction="vertical" color="primary">
-            <v-tab value="general">{{ $t("settings.general") }}</v-tab>
-            <v-tab value="proxy">{{ $t("proxy.name") }}</v-tab>
-            <v-tab value="chat">{{ $t("chat.name") }}</v-tab>
-            <v-tab
-              v-for="(setting, index) in botSettings"
-              :key="index"
-              :value="index"
-            >
-              {{ $t(`${setting.brand}.name`) }}
-            </v-tab>
-          </v-tabs>
-        </v-col>
-        <v-col>
-          <v-list lines="two" subheader>
-            <div v-if="tab == 'general'">
-              <v-list-item>
-                <v-list-item-title>{{
-                  $t("settings.language")
-                }}</v-list-item-title>
-                <v-select
-                  :items="languages"
-                  item-title="name"
-                  item-value="code"
-                  hide-details
-                  :model-value="lang"
-                  @update:model-value="setCurrentLanguage($event)"
-                ></v-select>
-              </v-list-item>
-              <v-list-item>
-                <v-list-item-title>{{
-                  $t("settings.theme")
-                }}</v-list-item-title>
-                <v-select
-                  :items="modes"
-                  item-title="name"
-                  item-value="code"
-                  hide-details
-                  :model-value="currentMode"
-                  @update:model-value="setCurrentMode($event)"
-                ></v-select>
-              </v-list-item>
-            </div>
+          <v-btn icon dark @click="closeDialog">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-toolbar>
+        <v-row style="height: calc(100% - 100px)">
+          <v-col cols="2" class="h-100 overflow-auto pr-0">
+            <v-tabs v-model="tab" direction="vertical" color="primary">
+              <v-tab value="general">{{ $t("settings.general") }}</v-tab>
+              <v-tab value="proxy">{{ $t("proxy.name") }}</v-tab>
+              <v-tab value="chat">{{ $t("chat.name") }}</v-tab>
+              <v-tab
+                v-for="(setting, index) in botSettings"
+                :key="index"
+                :value="index"
+              >
+                {{ $t(`${setting.brand}.name`) }}
+              </v-tab>
+            </v-tabs>
+          </v-col>
+          <v-col class="h-100 overflow-auto">
+            <v-list lines="two" subheader>
+              <div v-if="tab == 'general'">
+                <v-list-item>
+                  <v-list-item-title>{{
+                    $t("settings.language")
+                  }}</v-list-item-title>
+                  <v-select
+                    :items="languages"
+                    item-title="name"
+                    item-value="code"
+                    hide-details
+                    :model-value="lang"
+                    @update:model-value="setCurrentLanguage($event)"
+                  ></v-select>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title>{{
+                    $t("settings.theme")
+                  }}</v-list-item-title>
+                  <v-select
+                    :items="modes"
+                    item-title="name"
+                    item-value="code"
+                    hide-details
+                    :model-value="currentMode"
+                    @update:model-value="setCurrentMode($event)"
+                  ></v-select>
+                </v-list-item>
+              </div>
 
-            <div v-if="tab == 'proxy'">
-              <component :is="proxy"></component>
-            </div>
+              <div v-if="tab == 'proxy'">
+                <component :is="proxy"></component>
+              </div>
 
-            <div v-if="tab == 'chat'">
-              <component :is="chat" @close-dialog="closeDialog"></component>
-            </div>
+              <div v-if="tab == 'chat'">
+                <component :is="chat" @close-dialog="closeDialog"></component>
+              </div>
 
-            <template v-for="(setting, index) in botSettings" :key="index">
-              <component
-                v-if="tab == index"
-                :is="setting.component"
-              ></component>
-            </template>
-          </v-list>
-        </v-col>
-      </v-row>
+              <template v-for="(setting, index) in botSettings" :key="index">
+                <component
+                  v-if="tab == index"
+                  :is="setting.component"
+                ></component>
+              </template>
+            </v-list>
+          </v-col>
+        </v-row>
+      </div>
     </v-card>
   </v-dialog>
 </template>


### PR DESCRIPTION
The bot settings tabs has become longer.

When user click a bot setting tab on bottom, they need to scroll up again to see the settings at the top.

Updated the setting layout to make the left side bot setting tabs scrollable.
