### PR TITLE
Update message button background color

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -519,4 +519,8 @@ function toggleReplyButton() {
   height: 20px;
   margin-right: 4px;
 }
+
+.v-btn {
+  background-color: inherit;
+}
 </style>


### PR DESCRIPTION
In dark mode, background color of the button and the the response div are different.

Updated the button background color to inherit the response div color, making dark and light theme consistent.

![image](https://github.com/sunner/ChatALL/assets/26683979/75fd428c-23cc-4911-bf4b-0401c3190534)