### PR TITLE
Fix hidden bottom border of highlight in thread response

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -504,6 +504,7 @@ function toggleReplyButton() {
   width: 99%;
   grid-column: auto / span 1;
   margin: auto;
+  margin-bottom: 0.2rem;
 }
 
 .title {


### PR DESCRIPTION
Fix the highlight border on the bottom hidden in thread

![image](https://github.com/sunner/ChatALL/assets/26683979/b19dfb31-6d68-43e1-b56c-bd5921ee6ba1)
