### PR TITLE
fullscreen app window when startup

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -123,7 +123,9 @@ async function createWindow() {
   });
 
   mainWindow = win;
-
+  win.webContents.on("did-finish-load", () => {
+    win.maximize();
+  });
   // Force the SameSite attribute to None for all cookies
   // This is required for the cross-origin request to work
   win.webContents.session.cookies.on(


### PR DESCRIPTION
当窗口的webContents加载完成后，调用win.maximize()方法将窗口最大化