### PR TITLE
Improve error display

### DIFF
--- a/src/bots/Bot.js
+++ b/src/bots/Bot.js
@@ -183,7 +183,10 @@ export default class Bot {
       }
     } catch (err) {
       console.error(`Error send prompt to ${this.getFullname()}:`, err);
-      onUpdateResponse(callbackParam, { content: err.toString(), done: true }); // Make sure stop loading
+      onUpdateResponse(callbackParam, {
+        content: this.wrapCollapsedSection(err),
+        done: true,
+      }); // Make sure stop loading
     }
   }
 
@@ -230,5 +233,18 @@ export default class Bot {
       botClassname: this.getClassname(),
       context,
     });
+  }
+
+  wrapCollapsedSection(text) {
+    // replace line break with <br/>
+    text = text?.toString()?.replace(/[\r\n]+/g, "<br/>");
+    return `<details open>
+              <summary>Error</summary>
+              <pre class="error">${text}</pre>
+            </details>`;
+  }
+
+  getSSEDisplayError(event) {
+    return `${event?.source?.xhr?.status}\n${event?.source?.xhr?.response}`;
   }
 }

--- a/src/bots/PiBot.js
+++ b/src/bots/PiBot.js
@@ -80,7 +80,7 @@ export default class PiBot extends Bot {
               ),
             );
           } else {
-            reject(new Error(event));
+            reject(this.getSSEDisplayError(event));
           }
         });
         source.stream();

--- a/src/bots/QianWenBot.js
+++ b/src/bots/QianWenBot.js
@@ -118,7 +118,7 @@ export default class QianWenBot extends Bot {
 
         source.addEventListener("error", (event) => {
           console.error(event);
-          reject(new Error(event));
+          reject(this.getSSEDisplayError(event));
         });
 
         source.stream();

--- a/src/bots/YouChatBot.js
+++ b/src/bots/YouChatBot.js
@@ -97,7 +97,7 @@ export default class YouChatBot extends Bot {
         });
         source.addEventListener("error", (event) => {
           console.error(event);
-          reject(new Error(event));
+          reject(this.getSSEDisplayError(event));
         });
         source.stream();
       } catch (err) {

--- a/src/bots/lmsys/LMSYSBot.js
+++ b/src/bots/lmsys/LMSYSBot.js
@@ -40,7 +40,7 @@ export default class LMSYSBot extends GradioBot {
     if (errorMsg.includes("REFRESH THIS PAGE")) {
       errorMsg = errorMsg.replace(
         "REFRESH THIS PAGE",
-        `<a href="${this.constructor._loginUrl}" target="innerWindow">REFRESH THIS PAGE</a>`,
+        `\n<a href="${this.constructor._loginUrl}" target="innerWindow">REFRESH THIS PAGE</a>`,
       );
     }
     return errorMsg;

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -501,4 +501,9 @@ function toggleReplyButton() {
 .v-btn {
   background-color: inherit;
 }
+
+:deep() pre.error {
+  max-height: 200px;
+  background-color: inherit;
+}
 </style>


### PR DESCRIPTION
Display the error content instead of `Error: [object CustomEvent]`

![image](https://github.com/sunner/ChatALL/assets/26683979/d9230a4c-1da0-4ee2-a646-a6891e910c3a)
