### PR TITLE
Fix Pi Unauthorized error

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -156,7 +156,8 @@
     "name": "YouChat"
   },
   "pi": {
-    "name": "Pi"
+    "name": "Pi",
+    "waitPiIntro": "Please click the chatbot website link below and wait for the Pi introduction to finish, then close the window."
   },
   "dev": {
     "name": "Dev Bot"

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -156,7 +156,8 @@
     "name": "YouChat"
   },
   "pi": {
-    "name": "Pi"
+    "name": "Pi",
+    "waitPiIntro": "请点击下面的网站链接，等待Pi介绍完成后，然后关闭窗口。"
   },
   "dev": {
     "name": "开发专用 Bot"


### PR DESCRIPTION
I found that in the latest version, the Pi should be enabled by default, but it is still disabled due to `checkAvailability`.

So, I have updated it to simply return `true`, since the bot allows anonymous anyway.

I also found Pi possible to return 401 error when user send message for the first time.

This error can be fixed by visiting the Pi website and waiting for the Pi introduction.

Therefore, I have added a message asking users to visit the Pi website.

![image](https://github.com/sunner/ChatALL/assets/26683979/0998f8a3-d6a0-400a-a670-03d1f8f69a48)
![image](https://github.com/sunner/ChatALL/assets/26683979/f0ee813e-ca42-4f1c-afc1-785b5d892d35)
