### PR TITLE
Handle Cloudflare Challenge page

### DIFF
--- a/src/bots/Bot.js
+++ b/src/bots/Bot.js
@@ -245,6 +245,17 @@ export default class Bot {
   }
 
   getSSEDisplayError(event) {
+    if (event?.source?.xhr?.getResponseHeader("cf-mitigated") === "challenge") {
+      // if encounter Cloudflare challenge page, prompt user to open link and solve challenge
+      return `${i18n.global.t(
+        "error.solveChallenge",
+      )}\n${this.getLoginHyperlink()}`;
+    }
     return `${event?.source?.xhr?.status}\n${event?.source?.xhr?.response}`;
+  }
+
+  getLoginHyperlink() {
+    const url = this.getLoginUrl();
+    return `<a href="${url}" target="innerWindow">${url}</a>`;
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -31,7 +31,8 @@
   },
   "error": {
     "failedConnectUrl": "Failed to connect { url }",
-    "closedByServer": "Connection closed by server"
+    "closedByServer": "Connection closed by server",
+    "solveChallenge": "Kindly click on the link below, follow the instructions on the page to solve challenges / CAPTCHA, then close the window."
   },
   "modal": {
     "confirmHide": "Delete this message?",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -31,7 +31,8 @@
   },
   "error": {
     "failedConnectUrl": "连接 { url } 失败",
-    "closedByServer": "连接被服务器关闭"
+    "closedByServer": "连接被服务器关闭",
+    "solveChallenge": "请点击下方链接，按页面指示完成质询 / 验证码，然后关闭窗口。"
   },
   "modal": {
     "confirmHide": "删除这条消息？",


### PR DESCRIPTION
Enable YouChat by default because found that it actually allows anonymous access.

---

Then I do some testing, and found that Pi and YouChat hit 403 error:
![image](https://github.com/sunner/ChatALL/assets/26683979/5bedb416-d415-4042-a0e0-14b10482a077)

The error is caused by Cloudflare Turnstile, requires users to solve a CAPTCHA before accessing the website.
So I updated the `getSSEDisplayError` function to prompt users to solve the CAPTCHA.
To display this error only for Pi and YouChat, I added the `_isUseCloudflareTurnstile = true` static variable.
![image](https://github.com/sunner/ChatALL/assets/26683979/47db44ae-f216-4aa2-8742-4dfaaca8cf85)

---

I also modified the error text style to enable word wrap, to prevent horizontal scroll when the text is too long.
![image](https://github.com/sunner/ChatALL/assets/26683979/2d138e25-10c6-4b0d-bff7-b5c7bd51d53c)
