### PR TITLE
Show button on hover

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -19,13 +19,20 @@
         icon
         @click="toggleHighlight"
         :color="isHighlighted ? 'primary' : ''"
+        :class="getButtonClass"
       >
         <v-icon>mdi-lightbulb-on-outline</v-icon>
       </v-btn>
-      <v-btn flat size="x-small" icon @click="copyToClipboard">
+      <v-btn
+        flat
+        size="x-small"
+        icon
+        @click="copyToClipboard"
+        :class="getButtonClass"
+      >
         <v-icon>mdi-content-copy</v-icon>
       </v-btn>
-      <v-btn flat size="x-small" icon @click="hide">
+      <v-btn flat size="x-small" icon @click="hide" :class="getButtonClass">
         <v-icon>mdi-delete</v-icon>
       </v-btn>
     </v-card-title>
@@ -258,6 +265,10 @@ const isShowResendButton = computed(() => {
   }
 });
 const isShowPagingButton = computed(() => props.messages.length > 1);
+const getButtonClass = computed(() => ({
+  "hide-btn": !props.isThread,
+  "hide-thread-btn": props.isThread,
+}));
 
 // Send the prompt when the user presses enter and prevent the default behavior
 // But if the shift, ctrl, alt, or meta keys are pressed, do as default
@@ -506,5 +517,14 @@ function toggleReplyButton() {
   max-height: 200px;
   white-space: inherit;
   background-color: inherit;
+}
+
+.hide-btn, .hide-thread-btn {
+  transition: 0.3s;
+  opacity: 0;
+}
+    
+.response:hover .hide-btn, .response-thread:hover .hide-thread-btn {
+  opacity: 1;
 }
 </style>


### PR DESCRIPTION
Show the highlight, copy, and delete buttons on hover.

This can simplify the user interface, less clutter.

The page left/right buttons, reply, and resend buttons are show on hover, as they appear conditionally.

Before
![image](https://github.com/sunner/ChatALL/assets/26683979/10b5358a-86eb-408a-ab03-50c5d183a844)

After
![image](https://github.com/sunner/ChatALL/assets/26683979/ddd4e8cc-4265-47f6-975c-dee831526373)
