### PR TITLE
Fix shortcut guide style

### DIFF
--- a/src/components/ShortcutGuide/ShortcutGuide.vue
+++ b/src/components/ShortcutGuide/ShortcutGuide.vue
@@ -9,7 +9,7 @@
       style="
         position: absolute;
         top: 0;
-        left: 15px;
+        left: 0;
         width: 100vw;
         height: 100vh;
       "
@@ -25,7 +25,7 @@
 
 <script setup>
 const props = defineProps(["open"]);
-const emit = defineEmits(["update:open", "done"]);
+const emit = defineEmits(["update:open"]);
 
 import { ref } from "vue";
 import { onUpdated } from "vue";
@@ -88,7 +88,6 @@ const toggleShortcutGuide = () => {
 const closeShortcutGuide = () => {
   window.removeEventListener("resize", closeShortcutGuide);
   emit("update:open", false);
-  emit("done");
 };
 
 const openShortcutGuide = () => {
@@ -111,5 +110,18 @@ defineExpose({
 :deep() span {
   line-height: 1rem;
   color: rgb(var(--v-theme-font));
+}
+
+:deep() kbd {
+  padding: 3px 5px;
+  font: 11px ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  line-height: 10px;
+  color: rgb(var(--v-theme-font));
+  vertical-align: middle;
+  background-color: rgb(var(--v-theme-background));
+  border: solid 1px rgba(110,118,129,0.4);
+  border-bottom-color: rgba(110,118,129,0.4);
+  border-radius: 6px;
+  box-shadow: inset 0 -1px 0 rgba(110,118,129,0.4);
 }
 </style>

--- a/src/components/ShortcutGuide/shortcut.const.js
+++ b/src/components/ShortcutGuide/shortcut.const.js
@@ -58,7 +58,6 @@ export const SHORTCUT_CHAT_DRAWER = {
   elementId: "chat-drawer-btn",
   key: [modifier, "d"],
   offset: {
-    left: -10,
     top: 40,
   },
   flexDirection: "column",
@@ -88,7 +87,6 @@ export const SHORTCUT_LIST = [
     key: ["f1"],
     offset: {
       top: 30,
-      left: -5,
     },
   },
   {
@@ -96,7 +94,6 @@ export const SHORTCUT_LIST = [
     key: ["f2"],
     offset: {
       top: 30,
-      left: -5,
     },
   },
   {
@@ -104,7 +101,6 @@ export const SHORTCUT_LIST = [
     key: ["f3"],
     offset: {
       top: 30,
-      left: -5,
     },
   },
   {


### PR DESCRIPTION
Fix the shortcut guide style after changing to the new markdown component.
![image](https://github.com/sunner/ChatALL/assets/26683979/3d3a87a9-010b-4ed8-87b1-9a60312a54e9)


Copied `kbd` css from
[github-markdown-css](https://github.com/sindresorhus/github-markdown-css/blob/5ec832f378e36706bc1af26c65d5f0655ab33ef4/github-markdown-dark.css#L250-L262)