### PR TITLE
Apply invert filter to response bot logo

### DIFF
--- a/src/bots/Bot.js
+++ b/src/bots/Bot.js
@@ -9,6 +9,7 @@ export default class Bot {
   static _className = "Bot"; // Class name of the bot
   static _model = ""; // Model of the bot (eg. "text-davinci-002-render-sha")
   static _logoFilename = "default-logo.svg"; // Place it in public/bots/
+  static _isDarkLogo = false; // True if the main color of logo is dark
   static _loginUrl = "undefined";
   static _userAgent = ""; // Empty string means using the default user agent
   static _lock = null; // AsyncLock for prompt requests. `new AsyncLock()` in the subclass as needed.
@@ -23,6 +24,10 @@ export default class Bot {
 
   getLogo() {
     return `bots/${this.constructor._logoFilename}`;
+  }
+
+  isDarkLogo() {
+    return this.constructor._isDarkLogo;
   }
 
   getBrandName() {

--- a/src/bots/DevBot.js
+++ b/src/bots/DevBot.js
@@ -4,6 +4,7 @@ export default class DevBot extends Bot {
   static _brandId = "dev"; // Brand id of the bot, should be unique. Used in i18n.
   static _className = "DevBot"; // Class name of the bot
   static _logoFilename = "default-logo.svg"; // Place it in public/bots/
+  static _isDarkLogo = true; // The main color of logo is dark
   static _loginUrl = "http://chatall.ai";
   static _isAvailable = true;
 

--- a/src/bots/SkyWorkBot.js
+++ b/src/bots/SkyWorkBot.js
@@ -8,6 +8,7 @@ export default class SkyWorkBot extends Bot {
   static _brandId = "skyWork"; // Brand id of the bot, should be unique. Used in i18n.
   static _className = "SkyWorkBot"; // Class name of the bot
   static _logoFilename = "skywork-logo.png"; // Place it in public/bots/
+  static _isDarkLogo = true; // The main color of logo is dark
   static _loginUrl = "https://neice.tiangong.cn/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 

--- a/src/bots/microsoft/AzureOpenAIAPIBot.js
+++ b/src/bots/microsoft/AzureOpenAIAPIBot.js
@@ -6,6 +6,7 @@ export default class AzureOpenAIAPIBot extends LangChainBot {
   static _brandId = "azureOpenaiApi";
   static _className = "AzureOpenAIAPIBot";
   static _logoFilename = "azure-openai-logo.png";
+  static _isDarkLogo = true; // The main color of logo is dark
 
   constructor() {
     super();

--- a/src/bots/openai/OpenAIAPI3516KBot.js
+++ b/src/bots/openai/OpenAIAPI3516KBot.js
@@ -3,6 +3,7 @@ import OpenAIAPIBot from "./OpenAIAPIBot";
 export default class OpenAIAPI3516KBot extends OpenAIAPIBot {
   static _className = "OpenAIAPI3516KBot"; // Class name of the bot
   static _logoFilename = "openai-35-16k-logo.png"; // Place it in public/bots/
+  static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-3.5-turbo-16k";
 
   constructor() {

--- a/src/bots/openai/OpenAIAPI35Bot.js
+++ b/src/bots/openai/OpenAIAPI35Bot.js
@@ -3,6 +3,7 @@ import OpenAIAPIBot from "./OpenAIAPIBot";
 export default class OpenAIAPI35Bot extends OpenAIAPIBot {
   static _className = "OpenAIAPI35Bot"; // Class name of the bot
   static _logoFilename = "openai-35-logo.png"; // Place it in public/bots/
+  static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-3.5-turbo";
 
   constructor() {

--- a/src/bots/openai/OpenAIAPI4Bot.js
+++ b/src/bots/openai/OpenAIAPI4Bot.js
@@ -3,6 +3,7 @@ import OpenAIAPIBot from "./OpenAIAPIBot";
 export default class OpenAIAPI4Bot extends OpenAIAPIBot {
   static _className = "OpenAIAPI4Bot"; // Class name of the bot
   static _logoFilename = "openai-4-logo.png"; // Place it in public/bots/
+  static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4";
 
   constructor() {

--- a/src/components/Footer/BotLogo.vue
+++ b/src/components/Footer/BotLogo.vue
@@ -1,7 +1,7 @@
 <template>
   <v-avatar
     rounded="rounded"
-    :class="{ active: active, filter: enable_filter(bot) }"
+    :class="{ active: active, invert: isLogoInverted }"
     :image="bot.getLogo()"
     :alt="bot.getFullname()"
     :title="bot.getFullname()"
@@ -9,26 +9,15 @@
 </template>
 
 <script setup>
+import { computed } from "vue";
 import { useStore } from "vuex";
 import { Theme } from "@/theme";
 
 const store = useStore();
-
-defineProps(["bot", "active"]);
-
-function enable_filter(bot) {
-  const dark_icon_classname = [
-    "OpenAIAPI35Bot",
-    "OpenAIAPI3516KBot",
-    "OpenAIAPI4Bot",
-    "SkyWorkBot",
-    "AzureOpenAIAPIBot",
-    "DevBot",
-  ];
-  const is_dark = store.state.theme == Theme.DARK;
-  const is_dark_bot = dark_icon_classname.includes(bot.getClassname());
-  return is_dark && is_dark_bot;
-}
+const props = defineProps(["bot", "active"]);
+const isLogoInverted = computed(() => {
+  return store.state.theme === Theme.DARK && props.bot?.isDarkLogo();
+});
 </script>
 
 <style>
@@ -43,7 +32,7 @@ function enable_filter(bot) {
   filter: grayscale(0%);
 }
 
-.filter{
+.invert{
   filter: invert(100%);
 }
 </style>

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -186,15 +186,16 @@ const replyRef = ref();
 const maxPage = computed(() => props.messages.length - 1);
 const carouselModel = ref(maxPage.value);
 const confirmModal = ref(null);
+const botInstance = computed(() => {
+  return bots.getBotByClassName(props.messages[0].className);
+});
 
 const botLogo = computed(() => {
-  const bot = bots.getBotByClassName(props.messages[0].className);
-  return bot ? bot.getLogo() : "";
+  return botInstance.value ? botInstance.value.getLogo() : "";
 });
 
 const botFullname = computed(() => {
-  const bot = bots.getBotByClassName(props.messages[0].className);
-  return bot ? bot.getFullname() : "";
+  return botInstance.value ? botInstance.value.getFullname() : "";
 });
 
 const isHighlighted = computed(() => props.messages[maxPage.value].highlight); // if last response is hightlighted, return true
@@ -288,13 +289,11 @@ function filterEnterKey(event) {
 function sendPromptToBot() {
   if (replyModel.value.trim() === "") return;
 
-  const botInstance = bots.getBotByClassName(props.messages[0].className);
-
   store.dispatch("sendPromptInThread", {
     responseIndex: props.messages[maxPage.value].index, // always send prompt in thread to last page
     threadIndex: props.messages[carouselModel.value].threadIndex,
     prompt: replyModel.value,
-    bot: botInstance,
+    bot: botInstance.value,
   });
 
   carouselModel.value = maxPage.value; // move to last page
@@ -412,10 +411,9 @@ function resendPrompt(responseMessage) {
         responseMessage.promptIndex
       ];
     if (promptMessage) {
-      const botInstance = bots.getBotByClassName(responseMessage.className);
       store.dispatch("sendPromptInThread", {
         prompt: promptMessage.content,
-        bot: botInstance,
+        bot: botInstance.value,
         promptIndex: responseMessage.promptIndex,
         responseIndex: responseMessage.index,
         threadIndex: props.threadIndex,
@@ -427,10 +425,9 @@ function resendPrompt(responseMessage) {
     const promptMessage =
       store.getters.currentChat.messages[responseMessage.promptIndex];
     if (promptMessage) {
-      const botInstance = bots.getBotByClassName(responseMessage.className);
       store.dispatch("sendPrompt", {
         prompt: promptMessage.content,
-        bots: [botInstance],
+        bots: [botInstance.value],
         promptIndex: responseMessage.promptIndex,
       });
     } else {

--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -10,7 +10,11 @@
     :flat="props.isThread"
   >
     <v-card-title class="title">
-      <img :src="botLogo" alt="Bot Icon" />
+      <img
+        :src="botLogo"
+        :class="{ invert: isBotLogoInverted }"
+        :alt="botFullname"
+      />
       {{ botFullname }}
       <v-spacer></v-spacer>
       <v-btn
@@ -155,6 +159,7 @@ import { useMatomo } from "@/composables/matomo";
 import ConfirmModal from "@/components/ConfirmModal.vue";
 import ChatThread from "./ChatThread.vue";
 import bots from "@/bots";
+import { Theme } from "@/theme";
 
 const props = defineProps({
   messages: {
@@ -196,6 +201,10 @@ const botLogo = computed(() => {
 
 const botFullname = computed(() => {
   return botInstance.value ? botInstance.value.getFullname() : "";
+});
+
+const isBotLogoInverted = computed(() => {
+  return store.state.theme === Theme.DARK && botInstance.value?.isDarkLogo();
 });
 
 const isHighlighted = computed(() => props.messages[maxPage.value].highlight); // if last response is hightlighted, return true
@@ -523,5 +532,9 @@ function toggleReplyButton() {
     
 .response:hover .hide-btn, .response-thread:hover .hide-thread-btn {
   opacity: 1;
+}
+
+.invert{
+  filter: invert(100%);
 }
 </style>


### PR DESCRIPTION
Add `_isLogoInvertedInDarkTheme` static variable to below bots, so that can be used in both `ChatResponse.vue` and `BotLogo.vue` to check if require invert filter.

https://github.com/sunner/ChatALL/blob/e34254abedc6ee2577baedc514fb66335550fb13/src/components/Footer/BotLogo.vue#L20-L27

---

Create `botInstance` computed property.

And refactor 5 parts of code in `ChatResponse.vue` that called `bots.getBotByClassName` to use `botInstance.value`
