### PR TITLE
Remove follow up bar space when no button show

### DIFF
--- a/src/components/Messages/ChatResponse.vue
+++ b/src/components/Messages/ChatResponse.vue
@@ -100,6 +100,7 @@
           flat
           icon
           size="x-small"
+          v-if="!(!isShowResendButton && !isShowReplyButton)"
           :style="{ visibility: isShowResendButton ? 'visible' : 'hidden' }"
           @click="resendPrompt(messages[0])"
         >
@@ -109,6 +110,7 @@
           flat
           icon
           size="x-small"
+          v-if="!(!isShowResendButton && !isShowReplyButton)"
           :style="{ visibility: isShowReplyButton ? 'visible' : 'hidden' }"
           :color="isShowReplyTextField ? 'primary' : ''"
           @click="toggleReplyButton"


### PR DESCRIPTION
The paging button will also align farthest to the right for previous responses.

![image](https://github.com/sunner/ChatALL/assets/26683979/4f9ca344-988f-47f3-9f7d-effc98f04d12)
