### PR TITLE
Fix robot answer content overlap with footer robot icons

### DIFF
--- a/src/components/Footer/FooterBar.vue
+++ b/src/components/Footer/FooterBar.vue
@@ -343,7 +343,7 @@ defineExpose({
 
 <style scoped>
 .footer {
-  background-color: transparent!important;
+  background-color: rgb(var(--v-theme-background));
   height: auto!important;
   display: flex;
   align-items: center!important;
@@ -358,6 +358,8 @@ defineExpose({
 .bot-logos {
   display: flex;
   flex-wrap: wrap;
+  height: 40px;
+  overflow: scroll;
   gap: 4px;
   align-items: center;
   padding-bottom: 0.5rem;


### PR DESCRIPTION
* Fixed the overlap of robot answer content and footer robot icons.
* Allowed users to swipe to view all selected robot icons when the screen is narrow.

Before pr:

<img width="614" alt="截屏2023-07-18 14 28 07" src="https://github.com/sunner/ChatALL/assets/3024299/a96828bc-1bcb-4816-9ec6-123c9674f8e7">

After:

<img width="743" alt="截屏2023-07-18 14 42 20" src="https://github.com/sunner/ChatALL/assets/3024299/3a6acdb5-4063-4768-8488-0cfbc0da0842">
