### PR TITLE
 fix: Handle poe error responses to indicate account may be banned

### DIFF
--- a/src/bots/poe/PoeBot.js
+++ b/src/bots/poe/PoeBot.js
@@ -223,6 +223,10 @@ export default class PoeBot extends Bot {
             console.debug("response", response);
           })
           .catch((error) => {
+            this.constructor._isAvailable = false;
+            if (error.code == 'ERR_BAD_REQUEST') {
+              error.message += '. Your account may be banned';
+            }
             reject(error);
           });
       } catch (error) {


### PR DESCRIPTION
The error response likely indicates the account is banned as #329 described


<img width="426" alt="截屏2023-07-23 17 43 19" src="https://github.com/sunner/ChatALL/assets/3024299/06a7ccb4-4104-49c1-a242-9df394e008b1">

