### PR TITLE
Feat: Replied language selection

### DIFF
--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -45,6 +45,16 @@
                     :model-value="lang"
                     @update:model-value="setCurrentLanguage($event)"
                   ></v-select>
+                  <v-switch
+                    v-model="enableRepliedLang"
+                    color="primary"
+                    hideDetails="auto"
+                    :label="`${$t('settings.enable_replied_lang')}: ${
+                      enableRepliedLang ? $t('header.yes') : $t('header.no')
+                    }`"
+                    inset
+                    @update:model-value="setRepliedLang($event)"
+                  ></v-switch>
                 </v-list-item>
                 <v-list-item>
                   <v-list-item-title>{{
@@ -171,11 +181,16 @@ const modes = computed(() => [
 ]);
 
 const lang = computed(() => store.state.lang);
+const enableRepliedLang = ref(store.state.enableRepliedLang);
 const currentMode = computed(() => store.state.mode);
 
 const setCurrentLanguage = (lang) => {
   locale.value = lang;
   store.commit("setCurrentLanguage", lang);
+};
+const setRepliedLang = (enable) => {
+  locale.enableRepliedLang = enable;
+  store.commit("enableRepliedLang", enable);
 };
 const setCurrentMode = async (mode) => {
   const resolvedTheme = await resolveTheme(mode, ipcRenderer);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -6,6 +6,7 @@
     "general": "General",
     "language": "Language",
     "languagePrompt": "Relaunch the app to apply the new language",
+    "enable_replied_lang": "The robot replies in this language",
     "loginOrOut": "Login/Logout",
     "loginOrOutPrompt": "Click the link below to log in or log out in the new window, and then close it",
     "notice": "Notice",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -6,6 +6,7 @@
     "general": "通用",
     "language": "语言",
     "languagePrompt": "新语言将在程序重新启动后生效",
+    "enable_replied_lang": "机器人使用该语言回答",
     "loginOrOut": "登入/登出",
     "loginOrOutPrompt": "点击下面链接，在新窗口内登录或登出。然后关闭此窗口",
     "notice": "注意",

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,6 +25,7 @@ export default createStore({
   state: {
     uuid: "",
     lang: "auto",
+    enableRepliedLang: false,
     columns: 2,
     openaiApi: {
       apiKey: "",
@@ -142,6 +143,9 @@ export default createStore({
     setCurrentLanguage(state, language) {
       state.lang = language;
       i18n.global.locale = language;
+    },
+    enableRepliedLang(state, enable) {
+      state.enableRepliedLang = enable;
     },
     setChatgpt(state, refreshCycle) {
       state.chatgpt.refreshCycle = refreshCycle;
@@ -365,7 +369,9 @@ export default createStore({
 
         // workaround for tracking message position
         message.index = currentChat.messages.push(message) - 1;
-
+        prompt = state.enableRepliedLang
+          ? `${prompt}. Replied by ${state.langName}`
+          : prompt;
         bot.sendPrompt(
           prompt,
           (indexes, values) =>


### PR DESCRIPTION
Allow users to select whether the robot response language follows the current application configuration language.

<img width="1323" alt="截屏2023-08-06 23 45 39" src="https://github.com/sunner/ChatALL/assets/3024299/68327f97-d357-4de5-b104-db93178faf8c">

设置前后回复语言不同：

<img width="489" alt="截屏2023-08-06 23 46 29" src="https://github.com/sunner/ChatALL/assets/3024299/d889524b-1440-429c-a9b0-38727aa118b2">
