### PR TITLE
Fix challenge required in ChatGPT 3.5 

### DIFF
--- a/src/bots/openai/ChatGPTBot.js
+++ b/src/bots/openai/ChatGPTBot.js
@@ -149,10 +149,7 @@ export default class ChatGPTBot extends Bot {
   }
 
   async getArkoseToken() {
-    if (
-      ChatGPTBot._myEnforcement &&
-      this.constructor._model !== "text-davinci-002-render-sha"
-    ) {
+    if (ChatGPTBot._myEnforcement) {
       return new Promise((resolve, reject) => {
         ChatGPTBot._arkosePromise = { resolve, reject };
         ChatGPTBot._myEnforcement.run();


### PR DESCRIPTION
Close: https://github.com/sunner/ChatALL/issues/563

Fix ChatGPT 3.5 still returns 418 errors in latest version due to the arkose token is null in the payload.