### PR TITLE
Fix Pi, Use sse.js@0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "md5": "^2.3.0",
         "prettier": "^3.0.0",
         "prettier-plugin-vue": "^1.1.6",
-        "sse.js": "github:mpetazzoni/sse.js"
+        "sse.js": "^0.6.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -18813,9 +18813,9 @@
     },
     "node_modules/sse.js": {
       "version": "0.6.1",
-      "resolved": "git+ssh://git@github.com/mpetazzoni/sse.js.git#a1fe83916f110fdc3ca16a879a9a404a98a2bbdd",
-      "dev": true,
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/sse.js/-/sse.js-0.6.1.tgz",
+      "integrity": "sha512-peXG6GnWqF5hnubhMw0WfB6rqQy7z7LaMBT067vqgQwC3gKz8JGFzexBSV80FqZ9JoUDwo3Xt5nxkrGrgbPrtA==",
+      "dev": true
     },
     "node_modules/ssri": {
       "version": "8.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "md5": "^2.3.0",
     "prettier": "^3.0.0",
     "prettier-plugin-vue": "^1.1.6",
-    "sse.js": "github:mpetazzoni/sse.js"
+    "sse.js": "^0.6.1"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
Since the recent update of `sse.js` on Aug 6, 2023, Pi bot no longer works in the latest version.

https://github.com/mpetazzoni/sse.js/commits/main

https://github.com/mpetazzoni/sse.js/commit/f6f78ecb56257a4911022afcfc39481e6c40fdec

`npm i sse.js@0.6.1`, which is the previous version before the recent update.

Prevent unintended updates of existing components caused by using GitHub repo as dependency.