### PR TITLE
Disable QUIC

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -11,6 +11,10 @@ const isDevelopment = process.env.NODE_ENV !== "production";
 const DEFAULT_USER_AGENT = ""; // Empty string to use the Electron default
 let mainWindow = null;
 
+// Disable QUIC
+// Prevent Cloudflare from detecting the real IP when using a proxy that bypasses UDP traffic
+app.commandLine.appendSwitch("disable-quic");
+
 const userDataPath = app.getPath("userData");
 const proxySettingPath = path.join(userDataPath, "proxySetting.json");
 const defaultProxySetting = {


### PR DESCRIPTION
Cloudflare uses QUIC (a transport over UDP) to detect IP addresses. When using a proxy that does not support proxying UDP traffic, Cloudflare can detect the real IP address and blocks the user from accessing may services. Disabling QUIC can solve this issue.

Also, considering that disabling QUIC does not bring a noticeable impact, I think it is sufficient to disable it globally without the need to include it in the settings page.