### PR TITLE
Add falcon setting with common bot settings

### DIFF
--- a/src/bots/huggingface/Falcon180bBot.js
+++ b/src/bots/huggingface/Falcon180bBot.js
@@ -1,6 +1,7 @@
 import GradioBot from "@/bots/huggingface/GradioBot";
 import AsyncLock from "async-lock";
 import axios from "axios";
+import store from "@/store";
 
 export default class Falcon180bBot extends GradioBot {
   static _brandId = "falcon"; // Brand id of the bot, should be unique. Used in i18n.
@@ -49,7 +50,15 @@ export default class Falcon180bBot extends GradioBot {
   makeData(fn_index, prompt) {
     let r = null;
     if (fn_index === this.constructor._fnIndexes[0]) {
-      r = [null, null, "", 0.9, 256, 0.9, 1.2];
+      r = [
+        null,
+        null,
+        "",
+        store.state.falcon.temperature,
+        store.state.falcon.maxNewTokens,
+        store.state.falcon.topP,
+        store.state.falcon.repetitionPenalty,
+      ];
     }
     return r;
   }

--- a/src/components/BotSettings/AzureOpenAIAPIBotSettings.vue
+++ b/src/components/BotSettings/AzureOpenAIAPIBotSettings.vue
@@ -1,111 +1,77 @@
 <template>
-  <v-list-item>
-    <v-list-item-title>{{
-      $t("azureOpenaiApi.azureOpenAIApiKey")
-    }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("settings.secretPrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="azureOpenaiApi.azureApiKey"
-      outlined
-      dense
-      placeholder="b40..."
-      @update:model-value="setAzureOpenaiApi({ azureApiKey: $event })"
-    ></v-text-field>
-    <v-list-item-title>{{
-      $t("azureOpenaiApi.azureApiInstanceName")
-    }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("azureOpenaiApi.azureApiInstanceNamePrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="azureOpenaiApi.azureApiInstanceName"
-      outlined
-      dense
-      @update:model-value="setAzureOpenaiApi({ azureApiInstanceName: $event })"
-    ></v-text-field>
-    <v-list-item-title>{{
-      $t("azureOpenaiApi.azureOpenAIApiDeploymentName")
-    }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("azureOpenaiApi.azureOpenAIApiDeploymentNamePrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="azureOpenaiApi.azureOpenAIApiDeploymentName"
-      outlined
-      dense
-      @update:model-value="
-        setAzureOpenaiApi({ azureOpenAIApiDeploymentName: $event })
-      "
-    ></v-text-field>
-    <v-list-item-title>{{
-      $t("azureOpenaiApi.azureOpenAIApiVersion")
-    }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("azureOpenaiApi.azureOpenAIApiVersionPrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="azureOpenaiApi.azureOpenAIApiVersion"
-      outlined
-      dense
-      @update:model-value="setAzureOpenaiApi({ azureOpenAIApiVersion: $event })"
-    ></v-text-field>
-
-    <v-list-item-title>{{
-      $t("azureOpenaiApi.temperature")
-    }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("azureOpenaiApi.temperaturePrompt")
-    }}</v-list-item-subtitle>
-    <v-slider
-      v-model="azureOpenaiApi.temperature"
-      color="primary"
-      :min="0"
-      :max="2"
-      :step="0.1"
-      thumb-label
-      show-ticks="always"
-      :ticks="temperatureLabels"
-      @update:model-value="setAzureOpenaiApi({ temperature: $event })"
-    ></v-slider>
-
-    <v-list-item-title>{{ $t("bot.pastRounds") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("bot.pastRoundsPrompt")
-    }}</v-list-item-subtitle>
-    <v-slider
-      v-model="azureOpenaiApi.pastRounds"
-      color="primary"
-      :min="0"
-      :max="10"
-      :step="1"
-      thumb-label
-      show-ticks
-      @update:model-value="setAzureOpenaiApi({ pastRounds: $event })"
-    ></v-slider>
-  </v-list-item>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setAzureOpenaiApi"
+  ></CommonBotSettings>
 </template>
 
 <script>
-import { mapState, mapMutations } from "vuex";
 import Bot from "@/bots/microsoft/AzureOpenAIAPIBot";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
 import i18n from "@/i18n";
+import { Type } from "./settings.const";
+
+const settings = [
+  {
+    type: Type.Text,
+    name: "azureApiKey",
+    title: i18n.global.t("azureOpenaiApi.azureOpenAIApiKey"),
+    description: i18n.global.t("settings.secretPrompt"),
+    placeholder: "b40...",
+  },
+  {
+    type: Type.Text,
+    name: "azureApiInstanceName",
+    title: i18n.global.t("azureOpenaiApi.azureApiInstanceName"),
+    description: i18n.global.t("azureOpenaiApi.azureApiInstanceNamePrompt"),
+  },
+  {
+    type: Type.Text,
+    name: "azureOpenAIApiDeploymentName",
+    title: i18n.global.t("azureOpenaiApi.azureOpenAIApiDeploymentName"),
+    description: i18n.global.t(
+      "azureOpenaiApi.azureOpenAIApiDeploymentNamePrompt",
+    ),
+  },
+  {
+    type: Type.Text,
+    name: "azureOpenAIApiVersion",
+    title: i18n.global.t("azureOpenaiApi.azureOpenAIApiVersion"),
+    description: i18n.global.t("azureOpenaiApi.azureOpenAIApiVersionPrompt"),
+  },
+  {
+    type: Type.Slider,
+    name: "temperature",
+    title: i18n.global.t("azureOpenaiApi.temperature"),
+    description: i18n.global.t("azureOpenaiApi.temperaturePrompt"),
+    min: 0,
+    max: 2,
+    step: 0.1,
+    ticks: {
+      0: i18n.global.t("azureOpenaiApi.temperature0"),
+      2: i18n.global.t("azureOpenaiApi.temperature2"),
+    },
+  },
+  {
+    type: Type.Slider,
+    name: "pastRounds",
+    title: i18n.global.t("bot.pastRounds"),
+    description: i18n.global.t("bot.pastRoundsPrompt"),
+    min: 0,
+    max: 10,
+    step: 1,
+  },
+];
 export default {
+  components: {
+    CommonBotSettings,
+  },
   data() {
     return {
-      bot: Bot.getInstance(),
-      temperatureLabels: {
-        0: i18n.global.t("azureOpenaiApi.temperature0"),
-        2: i18n.global.t("azureOpenaiApi.temperature2"),
-      },
+      settings: settings,
+      brandId: Bot._brandId,
     };
-  },
-  methods: {
-    ...mapMutations(["setAzureOpenaiApi"]),
-  },
-  computed: {
-    ...mapState(["azureOpenaiApi"]),
   },
 };
 </script>

--- a/src/components/BotSettings/CommonBotSettings.vue
+++ b/src/components/BotSettings/CommonBotSettings.vue
@@ -57,7 +57,7 @@
             @update:model-value="
               /* setFalcon({ temperature: validateInput(temperature, $event) }) */
               store.commit(mutationType, {
-                [setting.name]: validateSliderInput(refs[setting.name], $event),
+                [setting.name]: validateSliderInput(setting, $event),
               })
             "
           ></v-text-field>
@@ -102,10 +102,10 @@ onMounted(() => {
   }
 });
 
-function validateSliderInput(element, value) {
+function validateSliderInput(setting, value) {
   // validate input via keyboard within setting min and max
   value = value || 0; // set zero if empty string
-  const input = this.getInputElement(element);
+  const input = getInputElement(refs.value[setting.name]);
   const valuefloat = parseFloat(value);
   const inputMaxFloat = parseFloat(input.max);
   const inputMinFloat = parseFloat(input.min);

--- a/src/components/BotSettings/CommonBotSettings.vue
+++ b/src/components/BotSettings/CommonBotSettings.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-list-item>
+    <template v-for="setting in settings" :key="setting.name">
+      <v-list-item-title v-if="setting.title">
+        <!-- falcon.temperature -->
+        {{ setting.title }}</v-list-item-title
+      >
+      <v-list-item-subtitle v-if="setting.description">
+        <!-- falcon.temperaturePrompt -->
+        {{ setting.description }}</v-list-item-subtitle
+      >
+
+      <v-text-field
+        v-if="setting.type === Type.Text"
+        v-model="settingState[setting.name]"
+        outlined
+        dense
+        :label="setting.label"
+        :placeholder="setting.placeholder"
+        :hide-details="setting.hideDetails"
+        @update:model-value="
+          /* setFalcon({ temperature: $event }) */
+          store.commit(mutationType, { [setting.name]: $event })
+        "
+      ></v-text-field>
+      <v-slider
+        v-else-if="setting.type === Type.Slider"
+        v-model="settingState[setting.name] /* falcon.temperature */"
+        color="primary"
+        :min="setting.min"
+        :max="setting.max"
+        :step="setting.step"
+        :ticks="setting.ticks"
+        :show-ticks="
+          /* 'show-ticks' cause lag issue when the possible value to slide is large */
+          setting.ticks ? 'always' : false
+        "
+        thumb-label
+        @update:model-value="
+          /* setFalcon({ temperature: $event }) */
+          store.commit(mutationType, { [setting.name]: $event })
+        "
+      >
+        <template v-slot:append>
+          <v-text-field
+            v-model="settingState[setting.name] /* falcon.temperature */"
+            :ref="
+              (el) => {
+                refs[setting.name] = el;
+              }
+            "
+            type="number"
+            style="width: 100px"
+            density="compact"
+            hide-details
+            variant="outlined"
+            @update:model-value="
+              /* setFalcon({ temperature: validateInput(temperature, $event) }) */
+              store.commit(mutationType, {
+                [setting.name]: validateSliderInput(refs[setting.name], $event),
+              })
+            "
+          ></v-text-field>
+        </template>
+      </v-slider>
+    </template>
+  </v-list-item>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from "vue";
+import { useStore } from "vuex";
+import { Type } from "./settings.const";
+const store = useStore();
+const settingState = computed(() => store.state[props.brandId]);
+const refs = ref([]);
+const props = defineProps({
+  brandId: {
+    type: String,
+    required: true,
+  },
+  settings: {
+    type: Object,
+    required: true,
+  },
+  mutationType: {
+    type: String,
+    required: true,
+  },
+});
+
+onMounted(() => {
+  for (const setting of props.settings) {
+    if (setting.type !== Type.Slider) {
+      continue;
+    }
+    // Set the 'min', 'max' and 'step' attributes for the input type 'number' spin button
+    const inputElement = getInputElement(refs.value[setting.name]);
+    inputElement.min = setting.min;
+    inputElement.max = setting.max;
+    inputElement.step = setting.step;
+  }
+});
+
+function validateSliderInput(element, value) {
+  // validate input via keyboard within setting min and max
+  value = value || 0; // set zero if empty string
+  const input = this.getInputElement(element);
+  const valuefloat = parseFloat(value);
+  const inputMaxFloat = parseFloat(input.max);
+  const inputMinFloat = parseFloat(input.min);
+  if (valuefloat > inputMaxFloat) {
+    return inputMaxFloat;
+  } else if (valuefloat < inputMinFloat) {
+    return inputMinFloat;
+  } else {
+    return valuefloat;
+  }
+}
+
+function getInputElement(ref) {
+  return ref.$el.querySelector("input");
+}
+</script>

--- a/src/components/BotSettings/Falcon180bBotSettings.vue
+++ b/src/components/BotSettings/Falcon180bBotSettings.vue
@@ -1,18 +1,63 @@
 <template>
-  <login-setting :bot="bot"></login-setting>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setFalcon"
+  ></CommonBotSettings>
 </template>
 
 <script>
 import Bot from "@/bots/huggingface/Falcon180bBot";
-import LoginSetting from "@/components/BotSettings/LoginSetting.vue";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
+import i18n from "@/i18n";
+import { Type } from "./settings.const";
 
+const settings = [
+  {
+    type: Type.Slider,
+    name: "temperature",
+    title: i18n.global.t("falcon.temperature"),
+    description: i18n.global.t("falcon.temperaturePrompt"),
+    min: 0,
+    max: 1,
+    step: 0.05,
+  },
+  {
+    type: Type.Slider,
+    name: "maxNewTokens",
+    title: i18n.global.t("falcon.maxNewTokens"),
+    description: i18n.global.t("falcon.maxNewTokensPrompt"),
+    min: 0,
+    max: 8192,
+    step: 64,
+  },
+  {
+    type: Type.Slider,
+    name: "topP",
+    title: i18n.global.t("falcon.topP"),
+    description: i18n.global.t("falcon.topPPrompt"),
+    min: 0,
+    max: 1,
+    step: 0.05,
+  },
+  {
+    type: Type.Slider,
+    name: "repetitionPenalty",
+    title: i18n.global.t("falcon.repetitionPenalty"),
+    description: i18n.global.t("falcon.repetitionPenaltyPrompt"),
+    min: 1,
+    max: 2,
+    step: 0.05,
+  },
+];
 export default {
   components: {
-    LoginSetting,
+    CommonBotSettings,
   },
   data() {
     return {
-      bot: Bot.getInstance(),
+      settings: settings,
+      brandId: Bot._brandId,
     };
   },
 };

--- a/src/components/BotSettings/GradioAppBotSettings.vue
+++ b/src/components/BotSettings/GradioAppBotSettings.vue
@@ -1,47 +1,45 @@
 <template>
-  <v-list-item>
-    <v-list-item-title>{{ $t("gradio.url") }}</v-list-item-title>
-    <v-list-item-subtitle>{{ $t("gradio.urlPrompt") }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="gradio.url"
-      outlined
-      dense
-      :placeholder="
-        $t('settings.forExample', {
-          example: 'https://*.hf.space, http://127.0.0.1:7861',
-        })
-      "
-      @update:model-value="setGradio({ url: $event })"
-    ></v-text-field>
-    <v-list-item-title>{{ $t("gradio.fnIndex") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("gradio.fnIndexPrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="gradio.fnIndex"
-      outlined
-      dense
-      placeholder="0"
-      @update:model-value="setGradio({ fnIndex: $event })"
-    ></v-text-field>
-  </v-list-item>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setGradio"
+  ></CommonBotSettings>
 </template>
 
 <script>
-import { mapState, mapMutations } from "vuex";
 import Bot from "@/bots/huggingface/GradioAppBot";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
+import i18n from "@/i18n";
+import { Type } from "./settings.const";
+
+const settings = [
+  {
+    type: Type.Text,
+    name: "url",
+    title: i18n.global.t("gradio.url"),
+    description: i18n.global.t("gradio.urlPrompt"),
+    placeholder: i18n.global.t("settings.forExample", {
+      example: "https://*.hf.space, http://127.0.0.1:7861",
+    }),
+  },
+  {
+    type: Type.Text,
+    name: "fnIndex",
+    title: i18n.global.t("gradio.fnIndex"),
+    description: i18n.global.t("gradio.fnIndexPrompt"),
+    placeholder: "0",
+  },
+];
 
 export default {
+  components: {
+    CommonBotSettings,
+  },
   data() {
     return {
-      bot: Bot.getInstance(),
+      settings: settings,
+      brandId: Bot._brandId,
     };
-  },
-  methods: {
-    ...mapMutations(["setGradio"]),
-  },
-  computed: {
-    ...mapState(["gradio"]),
   },
 };
 </script>

--- a/src/components/BotSettings/OpenAIAPIBotSettings.vue
+++ b/src/components/BotSettings/OpenAIAPIBotSettings.vue
@@ -36,7 +36,7 @@ const settings = [
   {
     type: Type.Slider,
     name: "pastRounds",
-    title: i18n.global.t("bot.alterUrl"),
+    title: i18n.global.t("bot.pastRounds"),
     description: i18n.global.t("bot.pastRoundsPrompt"),
     min: 0,
     max: 10,
@@ -45,8 +45,8 @@ const settings = [
   {
     type: Type.Text,
     name: "alterUrl",
-    title: i18n.global.t("openaiApi.apiKey"),
-    description: i18n.global.t("settings.alterUrlPrompt"),
+    title: i18n.global.t("openaiApi.alterUrl"),
+    description: i18n.global.t("openaiApi.alterUrlPrompt"),
     placeholder: "https://your.proxy.com/v1",
   },
 ];

--- a/src/components/BotSettings/OpenAIAPIBotSettings.vue
+++ b/src/components/BotSettings/OpenAIAPIBotSettings.vue
@@ -1,81 +1,64 @@
 <template>
-  <v-list-item>
-    <v-list-item-title>{{ $t("openaiApi.apiKey") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("settings.secretPrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="openaiApi.apiKey"
-      outlined
-      dense
-      placeholder="sk-..."
-      @update:model-value="setOpenaiApi({ apiKey: $event })"
-    ></v-text-field>
-
-    <v-list-item-title>{{ $t("openaiApi.temperature") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("openaiApi.temperaturePrompt")
-    }}</v-list-item-subtitle>
-    <v-slider
-      v-model="openaiApi.temperature"
-      color="primary"
-      :min="0"
-      :max="2"
-      :step="0.1"
-      thumb-label
-      show-ticks="always"
-      :ticks="temperatureLabels"
-      @update:model-value="setOpenaiApi({ temperature: $event })"
-    ></v-slider>
-
-    <v-list-item-title>{{ $t("bot.pastRounds") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("bot.pastRoundsPrompt")
-    }}</v-list-item-subtitle>
-    <v-slider
-      v-model="openaiApi.pastRounds"
-      color="primary"
-      :min="0"
-      :max="10"
-      :step="1"
-      thumb-label
-      show-ticks
-      @update:model-value="setOpenaiApi({ pastRounds: $event })"
-    ></v-slider>
-
-    <v-list-item-title>{{ $t("openaiApi.alterUrl") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("openaiApi.alterUrlPrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="openaiApi.alterUrl"
-      outlined
-      dense
-      placeholder="https://your.proxy.com/v1"
-      @update:model-value="setOpenaiApi({ alterUrl: $event })"
-    ></v-text-field>
-  </v-list-item>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setOpenaiApi"
+  ></CommonBotSettings>
 </template>
 
 <script>
-import { mapState, mapMutations } from "vuex";
 import Bot from "@/bots/openai/OpenAIAPIBot";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
 import i18n from "@/i18n";
+import { Type } from "./settings.const";
+
+const settings = [
+  {
+    type: Type.Text,
+    name: "apiKey",
+    title: i18n.global.t("openaiApi.apiKey"),
+    description: i18n.global.t("settings.secretPrompt"),
+    placeholder: "sk-...",
+  },
+  {
+    type: Type.Slider,
+    name: "temperature",
+    title: i18n.global.t("openaiApi.temperature"),
+    description: i18n.global.t("openaiApi.temperaturePrompt"),
+    min: 0,
+    max: 2,
+    step: 0.1,
+    ticks: {
+      0: i18n.global.t("openaiApi.temperature0"),
+      2: i18n.global.t("openaiApi.temperature2"),
+    },
+  },
+  {
+    type: Type.Slider,
+    name: "pastRounds",
+    title: i18n.global.t("bot.alterUrl"),
+    description: i18n.global.t("bot.pastRoundsPrompt"),
+    min: 0,
+    max: 10,
+    step: 1,
+  },
+  {
+    type: Type.Text,
+    name: "alterUrl",
+    title: i18n.global.t("openaiApi.apiKey"),
+    description: i18n.global.t("settings.alterUrlPrompt"),
+    placeholder: "https://your.proxy.com/v1",
+  },
+];
 export default {
+  components: {
+    CommonBotSettings,
+  },
   data() {
     return {
-      bot: Bot.getInstance(),
-      temperatureLabels: {
-        0: i18n.global.t("openaiApi.temperature0"),
-        2: i18n.global.t("openaiApi.temperature2"),
-      },
+      settings: settings,
+      brandId: Bot._brandId,
     };
-  },
-  methods: {
-    ...mapMutations(["setOpenaiApi"]),
-  },
-  computed: {
-    ...mapState(["openaiApi"]),
   },
 };
 </script>

--- a/src/components/BotSettings/WenxinQianfanBotSettings.vue
+++ b/src/components/BotSettings/WenxinQianfanBotSettings.vue
@@ -1,59 +1,50 @@
 <template>
-  <v-list-item>
-    <v-list-item-title>API Key & Secret Key</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("settings.secretPrompt")
-    }}</v-list-item-subtitle>
-    <v-text-field
-      v-model="wenxinQianfan.apiKey"
-      outlined
-      dense
-      hide-details
-      label="API Key"
-      :placeholder="'2125NA8mQy7gC52Pq9BK3tvk'"
-      @update:model-value="setWenxinQianfan({ apiKey: $event })"
-    ></v-text-field>
-    <v-text-field
-      v-model="wenxinQianfan.secretKey"
-      outlined
-      dense
-      label="Secret Key"
-      :placeholder="'IWf2pyYm26fz8GgNAHdkPkznHgazlffQ'"
-      @update:model-value="setWenxinQianfan({ secretKey: $event })"
-    ></v-text-field>
-
-    <v-list-item-title>{{ $t("bot.pastRounds") }}</v-list-item-title>
-    <v-list-item-subtitle>{{
-      $t("bot.pastRoundsPrompt")
-    }}</v-list-item-subtitle>
-    <v-slider
-      v-model="wenxinQianfan.pastRounds"
-      color="primary"
-      :min="0"
-      :max="10"
-      :step="1"
-      thumb-label
-      show-ticks
-      hide-details
-      @update:model-value="setWenxinQianfan({ pastRounds: $event })"
-    ></v-slider>
-  </v-list-item>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setWenxinQianfan"
+  ></CommonBotSettings>
 </template>
 
 <script>
-import { mapState, mapMutations } from "vuex";
 import Bot from "@/bots/baidu/WenxinQianfanBot";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
+import i18n from "@/i18n";
+import { Type } from "./settings.const";
+
+const settings = [
+  {
+    type: Type.Text,
+    name: "apiKey",
+    title: "API Key & Secret Key",
+    description: i18n.global.t("settings.secretPrompt"),
+    placeholder: "2125NA8mQy7gC52Pq9BK3tvk",
+    hideDetails: true,
+  },
+  {
+    type: Type.Text,
+    name: "secretKey",
+    placeholder: "IWf2pyYm26fz8GgNAHdkPkznHgazlffQ",
+  },
+  {
+    type: Type.Slider,
+    name: "pastRounds",
+    title: i18n.global.t("bot.pastRounds"),
+    description: i18n.global.t("bot.pastRoundsPrompt"),
+    min: 0,
+    max: 10,
+    step: 1,
+  },
+];
 export default {
+  components: {
+    CommonBotSettings,
+  },
   data() {
     return {
-      bot: Bot.getInstance(),
+      settings: settings,
+      brandId: Bot._brandId,
     };
-  },
-  methods: {
-    ...mapMutations(["setWenxinQianfan"]),
-  },
-  computed: {
-    ...mapState(["wenxinQianfan"]),
   },
 };
 </script>

--- a/src/components/BotSettings/WenxinQianfanBotSettings.vue
+++ b/src/components/BotSettings/WenxinQianfanBotSettings.vue
@@ -18,12 +18,14 @@ const settings = [
     name: "apiKey",
     title: "API Key & Secret Key",
     description: i18n.global.t("settings.secretPrompt"),
+    label: "API Key",
     placeholder: "2125NA8mQy7gC52Pq9BK3tvk",
     hideDetails: true,
   },
   {
     type: Type.Text,
     name: "secretKey",
+    label: "Secret Key",
     placeholder: "IWf2pyYm26fz8GgNAHdkPkznHgazlffQ",
   },
   {

--- a/src/components/BotSettings/settings.const.js
+++ b/src/components/BotSettings/settings.const.js
@@ -1,0 +1,4 @@
+export const Type = {
+  Text: 0,
+  Slider: 1,
+};

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -214,7 +214,15 @@
   },
   "falcon": {
     "name": "Falcon",
-    "falcon-180b": "180b"
+    "falcon-180b": "180b",
+    "temperature": "Temperature",
+    "temperaturePrompt": "Higher values produce more diverse outputs",
+    "maxNewTokens": "Max new tokens",
+    "maxNewTokensPrompt": "The maximum numbers of new tokens",
+    "topP": "Top-p (nucleus sampling)",
+    "topPPrompt": "Higher values sample more low-probability tokens",
+    "repetitionPenalty": "Repetition penalty",
+    "repetitionPenaltyPrompt": "Penalize repeated tokens"
   },
   "dev": {
     "name": "Dev Bot"

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -83,6 +83,12 @@ export default createStore({
     poe: {
       formkey: "",
     },
+    falcon: {
+      temperature: 0.9,
+      maxNewTokens: 256,
+      topP: 0.9,
+      repetitionPenalty: 1.2,
+    },
     chats: [
       {
         title: "New Chat",
@@ -203,6 +209,9 @@ export default createStore({
     },
     setPoe(state, values) {
       state.poe = { ...state.poe, ...values };
+    },
+    setFalcon(state, values) {
+      state.falcon = { ...state.falcon, ...values };
     },
     setLatestPromptIndex(state, promptIndex) {
       const currentChat = state.chats[state.currentChatIndex];


### PR DESCRIPTION
Close: https://github.com/sunner/ChatALL/issues/541

Add falcon setting

Create a shared component `CommonBotSettings` to create bot setting with json

Update `AzureOpenAIAPIBotSettings`, `GradioAppBotSettings`, `OpenAIAPIBotSettings`, and `WenxinQianfanBotSettings`  to use `CommonBotSettings` 


<details>
  <summary>Test (above `CommonBotSettings`, bottom is existing code)</summary>


https://github.com/sunner/ChatALL/assets/26683979/1b45a769-2ee1-452d-9666-cc44559cc671


https://github.com/sunner/ChatALL/assets/26683979/21200ce6-a0d9-4e8b-b297-c199382bcd07


https://github.com/sunner/ChatALL/assets/26683979/fbfd4a9c-5be7-4837-a17c-0fc53c936a4d


https://github.com/sunner/ChatALL/assets/26683979/cb983bf3-4587-4b65-992e-24960edddc89


</details>

