### PR TITLE
Update package.json to resolve ghost dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "langchain": "~0.0.156",
     "localforage": "^1.10.0",
     "material-design-icons": "^3.0.1",
+    "prismjs": "^1.13.0",
+    "query-string": "^5.0.1",
     "rxjs": "^7.8.1",
     "sortablejs": "^1.15.0",
     "update-electron-app": "^2.0.1",


### PR DESCRIPTION
prismjs is used in src\main.js
query-string is used in src\bots\YouChatBot.js. However, the chatall project does not explicitly add dependencies on these two packages. When the dependencies of other packages such as normalize-url change, the project may not work.