### PR TITLE
Invoke setChatContext after updating invocationId

### DIFF
--- a/src/bots/BardBot.js
+++ b/src/bots/BardBot.js
@@ -82,6 +82,7 @@ export default class BardBot extends Bot {
         .then(({ data: resp }) => {
           const { text, ids } = parseResponse(resp);
           context.contextIds = ids;
+          this.setChatContext(context);
           onUpdateResponse(callbackParam, { content: text, done: true });
           resolve();
         })

--- a/src/bots/Qihoo360AIBrainBot.js
+++ b/src/bots/Qihoo360AIBrainBot.js
@@ -76,11 +76,13 @@ export default class Qihoo360AIBrainBot extends Bot {
         //Get CONVERSATIONID e.g: CONVERSATIONID####f9563471f24a088d
         source.addEventListener("100", (event) => {
           context.parentConversationId = event.data.split("####")[1];
+          this.setChatContext(context);
         });
 
         //Get MESSAGEID e.g: MESSAGEID####f9563471f24a088ddd34826b527ffdfb
         source.addEventListener("101", (event) => {
           context.parentMessageId = event.data.split("####")[1];
+          this.setChatContext(context);
         });
 
         //unable to answer the user's question.

--- a/src/bots/microsoft/BingChatBot.js
+++ b/src/bots/microsoft/BingChatBot.js
@@ -168,6 +168,7 @@ export default class BingChatBot extends Bot {
                 wsp.sendPacked({ type: 6 });
                 wsp.sendPacked(await this.makePromptRequest(prompt));
                 context.invocationId += 1;
+                this.setChatContext(context);
               } else if (event.type === 6) {
                 wsp.sendPacked({ type: 6 });
               } else if (event.type === 3) {


### PR DESCRIPTION
Close: https://github.com/sunner/ChatALL/issues/605
Close: https://github.com/sunner/ChatALL/issues/617

~~@sunner, it’s strange that the `invocationId` isn’t saved after incrementing. How did the old version work then? I’m confused. 😅~~

Oh, previously used vuex-persist to save chat context, but now chat-related data is saved to IndexedDB via Dexie.js, which does not have reactivity.