### PR TITLE
Fix: Resolve Claude AI "model_not_allowed" error by updating model version

### DIFF
--- a/src/bots/ClaudeAIBot.js
+++ b/src/bots/ClaudeAIBot.js
@@ -54,7 +54,7 @@ export default class ClaudeAIBot extends Bot {
       attachments: [],
       completion: {
         incremental: true,
-        model: "claude-2",
+        model: "claude-2.1",
         prompt: prompt,
       },
       conversation_uuid: context.uuid,


### PR DESCRIPTION
The Claude AI API was recently updated, causing an "Invalid model" error (403{"error":{"type":"permission_error","message":"Invalid model","code":"model_not_allowed"}}) when using the original model "claude-2". This commit addresses the issue by updating the model to "claude-2.1", resolving the permission error and ensuring smooth functionality with the latest API changes.

Related issues:

1. #631 
2. #632 
3. #634 
