### PR TITLE
Fix: Resolve BingChatBot Login Issue with Updated `loginUrl`

### DIFF
--- a/src/bots/microsoft/BingChatBot.js
+++ b/src/bots/microsoft/BingChatBot.js
@@ -9,7 +9,7 @@ export default class BingChatBot extends Bot {
   static _className = "BingChatBot"; // Class name of the bot
   static _model = "h3precise"; // Bing styles: h3imaginative, harmonyv3, h3precise
   static _logoFilename = "bing-logo.svg"; // Place it in public/bots/
-  static _loginUrl = "https://www.bing.com/new";
+  static _loginUrl = "https://www.bing.com/chat";
   static _userAgent =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 Edg/112.0.1722.48";
 


### PR DESCRIPTION
The original URL (https://www.bing.com/new) now redirects to the Microsoft official website, preventing users from logging into the Bing ChatBot. This commit updates the URL to https://www.bing.com/chat, resolving the login issue.

Related issues:

1. #660 
2. #662 