### PR TITLE
Update GPT-4 Turbo Preview to gpt-4-turbo-preview

### DIFF
--- a/src/bots/openai/OpenAIAPI4128KBot.js
+++ b/src/bots/openai/OpenAIAPI4128KBot.js
@@ -4,7 +4,7 @@ export default class OpenAIAPI4128KBot extends OpenAIAPIBot {
   static _className = "OpenAIAPI4128KBot"; // Class name of the bot
   static _logoFilename = "openai-4-128k-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
-  static _model = "gpt-4-1106-preview";
+  static _model = "gpt-4-turbo-preview";
 
   constructor() {
     super();

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -192,7 +192,7 @@
     "gpt-35-turbo": "gpt-3.5-turbo",
     "gpt-35-turbo-16k": "gpt-3.5-turbo-16k",
     "gpt-4": "gpt-4",
-    "gpt-4-1106-preview": "gpt-4-1106-preview",
+    "gpt-4-turbo-preview": "gpt-4-turbo-preview",
     "temperature": "Temperature",
     "temperaturePrompt": "The higher the temperature, the more creative the text, but the more likely it is to be incoherent",
     "temperature0": "More deterministic",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -148,7 +148,7 @@
     "gpt-35-turbo": "GPT-3.5-turbo",
     "gpt-35-turbo-16k": "GPT-3.5-Turbo-16K",
     "gpt-4": "GPT-4",
-    "gpt-4-1106-preview": "gpt-4-1106-preview",
+    "gpt-4-turbo-preview": "gpt-4-turbo-preview",
     "temperature": "Temperatura",
     "temperaturePrompt": "Cuanto mayor sea la temperatura, más creativo será el texto, pero más probable es que sea incoherente.",
     "temperature0": "Más determinista",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -128,7 +128,7 @@
     "gpt-35-turbo": "gpt-3.5-turbo",
     "gpt-35-turbo-16k": "gpt-3.5-turbo-16k",
     "gpt-4": "gpt-4",
-    "gpt-4-1106-preview": "gpt-4-1106-preview",
+    "gpt-4-turbo-preview": "gpt-4-turbo-preview",
     "temperature": "温度",
     "temperaturePrompt": "温度が高いほど、テキストは創造的ですが、一貫性がない可能性が高いです。",
     "temperature0": "より決定論的な",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -192,7 +192,7 @@
     "gpt-35-turbo": "gpt-3.5-터보",
     "gpt-35-turbo-16k": "gpt-3.5-터보-16k",
     "gpt-4": "gpt-4",
-    "gpt-4-1106-preview": "gpt-4-1106-미리보기",
+    "gpt-4-turbo-preview": "gpt-4-turbo-미리보기",
     "temperature": "온도",
     "temperaturePrompt": "온도가 높을수록 텍스트는 창의적이지만 일관성이 없을 가능성이 높습니다",
     "temperature0": "더 결정론적인",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -192,7 +192,7 @@
     "gpt-35-turbo": "gpt-3.5-turbo",
     "gpt-35-turbo-16k": "gpt-3.5-turbo-16k",
     "gpt-4": "gpt-4",
-    "gpt-4-1106-preview": "gpt-4-1106-preview",
+    "gpt-4-turbo-preview": "gpt-4-turbo-preview",
     "temperature": "Temperature",
     "temperaturePrompt": "Temperature càng cao, văn bản càng sáng tạo nhưng càng có khả năng trở nên rời rạc",
     "temperature0": "Cụ thể hơn",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -192,7 +192,7 @@
     "gpt-35-turbo": "gpt-3.5-turbo",
     "gpt-35-turbo-16k": "gpt-3.5-turbo-16k",
     "gpt-4": "gpt-4",
-    "gpt-4-1106-preview": "gpt-4-1106-preview",
+    "gpt-4-turbo-preview": "gpt-4-turbo-preview",
     "temperature": "Temperature",
     "temperaturePrompt": "Temperature 越高，生成的文本越有创造性，但也越没条理",
     "temperature0": "更具确定性",

--- a/src/i18n/locales/zhtw.json
+++ b/src/i18n/locales/zhtw.json
@@ -192,7 +192,7 @@
     "gpt-35-turbo": "gpt-3.5-turbo",
     "gpt-35-turbo-16k": "gpt-3.5-turbo-16k",
     "gpt-4": "gpt-4",
-    "gpt-4-1106-preview": "gpt-4-1106-preview",
+    "gpt-4-turbo-preview": "gpt-4-turbo-preview",
     "temperature": "Temperature",
     "temperaturePrompt": "Temperature 越高，生成的文字越有創造性，但也越沒條理",
     "temperature0": "更具確定性",


### PR DESCRIPTION
Though there are more and more versions of the GPT model, as the GPT-4 Turbo is still under preview, I think it's good enough just to replace the old one with the latest version.

Reference: https://openai.com/blog/new-embedding-models-and-api-updates