### PR TITLE
Add claude model setting

### DIFF
--- a/src/bots/ClaudeAIBot.js
+++ b/src/bots/ClaudeAIBot.js
@@ -53,7 +53,7 @@ export default class ClaudeAIBot extends Bot {
     const url = `https://claude.ai/api/organizations/${store.state.claudeAi.org}/chat_conversations/${context.uuid}/completion`;
     const payload = JSON.stringify({
       attachments: [],
-      model: "claude-2.1",
+      model: store.state.claudeAi.model,
       prompt: prompt,
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     });

--- a/src/components/BotSettings/ClaudeAIBotSettings.vue
+++ b/src/components/BotSettings/ClaudeAIBotSettings.vue
@@ -1,19 +1,38 @@
 <template>
   <login-setting :bot="bot"></login-setting>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setClaudeAi"
+  ></CommonBotSettings>
 </template>
 
 <script>
 import Bot from "@/bots/ClaudeAIBot";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
 import LoginSetting from "@/components/BotSettings/LoginSetting.vue";
 import { mapMutations } from "vuex";
+import { Type } from "./settings.const";
 const { ipcRenderer } = window.require("electron");
+
+const settings = [
+  {
+    type: Type.Combobox,
+    name: "model",
+    title: "Model",
+    items: ["claude-2.0", "claude-2.1", "claude-<edit me>"],
+  },
+];
 
 export default {
   components: {
     LoginSetting,
+    CommonBotSettings,
   },
   data() {
     return {
+      settings: settings,
+      brandId: Bot._brandId,
       bot: Bot.getInstance(),
     };
   },

--- a/src/components/BotSettings/CommonBotSettings.vue
+++ b/src/components/BotSettings/CommonBotSettings.vue
@@ -77,6 +77,19 @@
           ></v-text-field>
         </template>
       </v-slider>
+      <v-combobox
+        v-if="setting.type === Type.Combobox"
+        v-model="settingState[setting.name]"
+        outlined
+        dense
+        :label="setting.label"
+        :placeholder="setting.placeholder"
+        :hide-details="setting.hideDetails"
+        :items="setting.items"
+        @update:model-value="
+          store.commit(mutationType, { [setting.name]: $event })
+        "
+      ></v-combobox>
     </template>
   </v-list-item>
 </template>

--- a/src/components/BotSettings/settings.const.js
+++ b/src/components/BotSettings/settings.const.js
@@ -2,4 +2,5 @@ export const Type = {
   Text: 0,
   Slider: 1,
   Select: 2,
+  Combobox: 3,
 };

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -83,6 +83,7 @@ export default createStore({
     },
     claudeAi: {
       org: "",
+      model: "claude-2.0",
     },
     poe: {
       formkey: "",


### PR DESCRIPTION
Updated model to `claude-2.0` as hit same error in https://github.com/sunner/ChatALL/issues/685

Made model can be configured as a setting

Added combobox type setting

Use combobox as model setting to allow user enter their own value, e.g. `claude-3.0` in future without waiting for an update