### PR TITLE
Correct UI string and translations for Azure OAI "API version"

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -108,7 +108,7 @@
     "azureApiInstanceNamePrompt": "View the instance name at https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI",
     "azureOpenAIApiDeploymentName": "Deployment Name",
     "azureOpenAIApiDeploymentNamePrompt": "View the deployment name in Management -> Deployments at https://oai.azure.com/",
-    "azureOpenAIApiVersion": "Version",
+    "azureOpenAIApiVersion": "API Version",
     "azureOpenAIApiVersionPrompt": "Get the supported versions from https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions"
   },
   "bard": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -77,7 +77,7 @@
     "azureApiInstanceNamePrompt": "Ver el nombre de la instancia en https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI",
     "azureOpenAIApiDeploymentName": "Nombre de implementación",
     "azureOpenAIApiDeploymentNamePrompt": "Ver el nombre de la implementación en Management -> Deployments at https://oai.azure.com/",
-    "azureOpenAIApiVersion": "Versión",
+    "azureOpenAIApiVersion": "Versión de la API",
     "azureOpenAIApiVersionPrompt": "Obtenga las versiones compatibles de https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions"
   },
   "bard": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -65,7 +65,7 @@
     "azureApiInstanceNamePrompt": "https://portal.azure.com/ の Cognitive Services でインスタンス名を表示する。",
     "azureOpenAIApiDeploymentName": "デプロイメント名",
     "azureOpenAIApiDeploymentNamePrompt": "https://oai.azure.com/ の[管理] -> [デプロイメント]でデプロイメント名を表示します。",
-    "azureOpenAIApiVersion": "バージョン",
+    "azureOpenAIApiVersion": "API バージョン",
     "azureOpenAIApiVersionPrompt": "サポートされているバージョンを https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions から入手する。"
   },
   "bard": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -108,7 +108,7 @@
     "azureApiInstanceNamePrompt": "https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI에서 인스턴스 이름 보기",
     "azureOpenAIApiDeploymentName": "Azure OpenAI API 배포 이름",
     "azureOpenAIApiDeploymentNamePrompt": "https://oai.azure.com/ 에서 관리 -> 배포에서 배포 이름을 확인합니다",
-    "azureOpenAIApiVersion": "버전",
+    "azureOpenAIApiVersion": "API 버전",
     "azureOpenAIApiVersionPrompt": "https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions에서 지원되는 버전 다운로드"
   },
   "bard": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -108,7 +108,7 @@
     "azureApiInstanceNamePrompt": "Xem InstanceName ở mục Cognitive Services tại https://portal.azure.com/",
     "azureOpenAIApiDeploymentName": "Azure OpenAI API DeploymentName",
     "azureOpenAIApiDeploymentNamePrompt": "Xem tên nhà phát triển được liệt kê tại https://oai.azure.com/",
-    "azureOpenAIApiVersion": "Azure OpenAI API Version",
+    "azureOpenAIApiVersion": "Phiên bản Azure OpenAI API",
     "azureOpenAIApiVersionPrompt": "Xem phiên bản hổ trợ tại https://learn.microsoft.com/en-us/azure/cognitive-services/openai/reference#completions"
   },
   "bard": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -108,7 +108,7 @@
     "azureApiInstanceNamePrompt": "在 https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI 查看",
     "azureOpenAIApiDeploymentName": "部署名",
     "azureOpenAIApiDeploymentNamePrompt": "在 https://oai.azure.com/ 的「管理 -> 部署」下查看",
-    "azureOpenAIApiVersion": "模型版本",
+    "azureOpenAIApiVersion": "API 版本",
     "azureOpenAIApiVersionPrompt": "在 https://learn.microsoft.com/zh-cn/azure/cognitive-services/openai/reference#completions 查看支持的版本"
   },
   "bard": {

--- a/src/i18n/locales/zhtw.json
+++ b/src/i18n/locales/zhtw.json
@@ -108,7 +108,7 @@
     "azureApiInstanceNamePrompt": "在 https://portal.azure.com/#view/Microsoft_Azure_ProjectOxford/CognitiveServicesHub/~/OpenAI 檢視",
     "azureOpenAIApiDeploymentName": "部署名稱",
     "azureOpenAIApiDeploymentNamePrompt": "在 https://oai.azure.com/ 的「管理 -> 部署」下檢視",
-    "azureOpenAIApiVersion": "模型版本",
+    "azureOpenAIApiVersion": "API 版本",
     "azureOpenAIApiVersionPrompt": "在 https://learn.microsoft.com/zh-cn/azure/cognitive-services/openai/reference#completions 檢視支援的版本"
   },
   "bard": {


### PR DESCRIPTION
The old string might mislead the user that it was the model version, which was not.