### PR TITLE
Use updateElectronApp function from update-electron-app package

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -45,7 +45,7 @@ const getLatestVersionFromGithub = () => {
 const updateApp = (mainWindow) => {
   localMainWindow = mainWindow;
   autoUpdater.on("error", getLatestVersionFromGithub);
-  require("update-electron-app")();
+  require("update-electron-app").updateElectronApp();
 };
 
 export default updateApp;


### PR DESCRIPTION
Fix update notification not showing

Caused by breaking change from update-electron-app v3.0.0

https://github.com/electron/update-electron-app/releases/tag/v3.0.0