### PR TITLE
Fix update slowness by merging messages to reduce update frequency

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -164,6 +164,7 @@ import Chats from "@/store/chats";
 import { initializeQueues, startQueuesProcessing } from "@/store/queue";
 import { useObservable } from "@vueuse/rxjs";
 import { liveQuery } from "dexie";
+import { onScroll } from "./helpers/scroll-helper";
 
 // Components
 import ChatDrawer from "@/components/ChatDrawer/ChatDrawer.vue";
@@ -269,6 +270,8 @@ onMounted(() => {
 
   initializeQueues(store);
   startQueuesProcessing();
+
+  window.addEventListener("scroll", onScroll);
 });
 
 watch(

--- a/src/App.vue
+++ b/src/App.vue
@@ -161,6 +161,7 @@ import {
 
 import i18n from "./i18n";
 import Chats from "@/store/chats";
+import { initializeQueues, startQueuesProcessing } from "@/store/queue";
 import { useObservable } from "@vueuse/rxjs";
 import { liveQuery } from "dexie";
 
@@ -265,6 +266,9 @@ onMounted(() => {
 
   const ver = require("../package.json").version;
   document.title = `ChatALL.ai - v${ver}`;
+
+  initializeQueues(store);
+  startQueuesProcessing();
 });
 
 watch(

--- a/src/components/ChatSetting.vue
+++ b/src/components/ChatSetting.vue
@@ -1,4 +1,9 @@
 <template>
+  <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setChat"
+  ></CommonBotSettings>
   <v-list>
     <v-list-item>
       <v-btn
@@ -206,6 +211,7 @@
 import bots from "@/bots";
 import ConfirmModal from "@/components/ConfirmModal.vue";
 import ChatPrompt from "@/components/Messages/ChatPrompt.vue";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
 import i18n from "@/i18n";
 import Chats from "@/store/chats";
 import db from "@/store/db";
@@ -223,6 +229,7 @@ import {
   templatePlaceholder,
 } from "../helpers/template-helper";
 import { nextTick } from "vue";
+import { Type } from "./BotSettings/settings.const";
 
 const emit = defineEmits(["close-dialog"]);
 const confirmModal = ref();
@@ -269,6 +276,18 @@ const previewSampleData = [
   {
     botName: "YouChat",
     botResponse: "Hi there! How can I assist you today?",
+  },
+];
+const brandId = "chat";
+const settings = [
+  {
+    type: Type.Slider,
+    name: "updateDebounceInterval",
+    title: "chat.updateDebounceInterval",
+    description: "chat.updateDebounceIntervalDesc",
+    min: 0,
+    max: 2000,
+    step: 100,
   },
 ];
 let editIndex = undefined;

--- a/src/components/Messages/ChatMessages.vue
+++ b/src/components/Messages/ChatMessages.vue
@@ -29,10 +29,11 @@
 <script setup>
 import Messages from "@/store/messages";
 import { liveQuery } from "dexie";
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onMounted, ref, watch } from "vue";
 import { useStore } from "vuex";
 import ChatPrompt from "./ChatPrompt.vue";
 import ChatResponse from "./ChatResponse.vue";
+import { autoScrollToBottom, scrollToBottom } from "@/helpers/scroll-helper";
 
 const store = useStore();
 
@@ -46,7 +47,6 @@ const props = defineProps({
   },
 });
 
-const autoScroll = ref(true);
 const loading = ref(false);
 const gridTemplateColumns = computed(() => `repeat(${props.columns}, 1fr)`);
 const currentChatMessages = ref([]);
@@ -86,19 +86,6 @@ let createChatMessageLiveQuery = (index) => {
   });
 };
 
-const scrollToBottom = ({ immediately = false }) => {
-  window.scrollTo({
-    top: document.documentElement.scrollHeight,
-    behavior: immediately ? "instant" : "smooth",
-  });
-};
-
-const autoScrollToBottom = () => {
-  if (autoScroll.value) {
-    scrollToBottom({ immediately: true });
-  }
-};
-
 const currentChatIndex = computed(() => store.state.currentChatIndex);
 let currentMessageSub;
 let scrollToBottomFirst;
@@ -125,20 +112,10 @@ watch(
   { immediate: true },
 );
 
-const onScroll = () => {
-  const scrollPosition = window.pageYOffset + window.innerHeight;
-  autoScroll.value =
-    scrollPosition >= document.documentElement.scrollHeight - 40;
-};
-
 onMounted(async () => {
   await Messages.table
     .filter((message) => message.done !== true)
     .modify({ done: true });
-  window.addEventListener("scroll", onScroll);
-});
-onUnmounted(() => {
-  window.removeEventListener("scroll", onScroll);
 });
 </script>
 

--- a/src/components/Messages/ChatMessages.vue
+++ b/src/components/Messages/ChatMessages.vue
@@ -82,6 +82,7 @@ let createChatMessageLiveQuery = (index) => {
       groupedMessage.push.apply(groupedMessage, Object.values(responses));
     }
     currentChatMessages.value = groupedMessage;
+    nextTick(() => autoScrollToBottom());
   });
 };
 
@@ -123,8 +124,6 @@ watch(
   },
   { immediate: true },
 );
-
-watch(() => store.state.updateCounter, autoScrollToBottom);
 
 const onScroll = () => {
   const scrollPosition = window.pageYOffset + window.innerHeight;

--- a/src/components/Messages/ChatThread.vue
+++ b/src/components/Messages/ChatThread.vue
@@ -23,6 +23,8 @@ import ChatResponse from "@/components/Messages/ChatResponse.vue";
 import Threads from "@/store/threads";
 import { useObservable } from "@vueuse/rxjs";
 import { liveQuery } from "dexie";
+import { nextTick } from "vue";
+import { autoScrollToBottom } from "@/helpers/scroll-helper";
 
 const props = defineProps({
   chat: {
@@ -73,6 +75,7 @@ const currentChatMessages = useObservable(
     }
 
     currentChatMessages.value = groupedMessage;
+    nextTick(() => autoScrollToBottom());
     console.log("groupedMessage threads: ", groupedMessage);
     return groupedMessage;
   }),

--- a/src/helpers/scroll-helper.js
+++ b/src/helpers/scroll-helper.js
@@ -1,0 +1,19 @@
+export const scrollToBottom = ({ immediately = false }) => {
+  window.scrollTo({
+    top: document.documentElement.scrollHeight,
+    behavior: immediately ? "instant" : "smooth",
+  });
+};
+
+export const autoScrollToBottom = () => {
+  if (autoScroll) {
+    scrollToBottom({ immediately: true });
+  }
+};
+
+export const onScroll = () => {
+  const scrollPosition = window.pageYOffset + window.innerHeight;
+  autoScroll = scrollPosition >= document.documentElement.scrollHeight - 40;
+};
+
+export let autoScroll = false;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -81,7 +81,9 @@
     "description": "Description",
     "botNameDesc": "name of the selected response’s bot",
     "botResponseDesc": "the selected response",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "updateDebounceInterval": "Message Updating Interval (milliseconds)",
+    "updateDebounceIntervalDesc": "The value controls the message update speed when the AI bot responds. A higher value delays the message processing and updates them all at once, which is more efficient. A lower value updates the messages faster, but may cause performance issues."
   },
   "bot": {
     "creatingConversation": "Creating conversation...",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -81,7 +81,9 @@
     "description": "描述",
     "botNameDesc": "所选响应的机器人名称",
     "botResponseDesc": "所选响应内容",
-    "loading": "加载中..."
+    "loading": "加载中...",
+    "updateDebounceInterval": "消息更新间隔（毫秒）",
+    "updateDebounceIntervalDesc": "此值控制 AI 机器人回复时，消息更新速度。更高的值会延迟消息处理，并一次性更新所有消息，效率更高。更低的值会更快更新消息，但可能会导致性能问题。"
   },
   "bot": {
     "creatingConversation": "创建新对话...",

--- a/src/store/queue.js
+++ b/src/store/queue.js
@@ -1,0 +1,111 @@
+import Messages from "@/store/messages";
+import Threads from "@/store/threads";
+/* eslint-disable no-unused-vars */
+import { Table, UpdateSpec, TKey } from "dexie";
+import { Store } from "vuex";
+
+/** @type {Queue} */
+export let messageQueue;
+/** @type {Queue} */
+export let threadMessageQueue;
+
+/**
+ * @param {Store} store
+ */
+export function initializeQueues(store) {
+  messageQueue = new Queue(store, Messages.table, "messageQueue");
+  threadMessageQueue = new Queue(store, Threads.table, "threadMessageQueue");
+}
+
+export function startQueuesProcessing() {
+  messageQueue.processQueue();
+  threadMessageQueue.processQueue();
+}
+
+class Queue {
+  /** @type {Store} */
+  store;
+  /** @type {Table} */
+  table;
+  _queue = [];
+  queueName = "";
+  isProcessing = false;
+
+  static DEFAULT_UPDATE_DEBOUNCE_INTERVAL = 100;
+  debounceTime = Queue.DEFAULT_UPDATE_DEBOUNCE_INTERVAL;
+
+  get queue() {
+    return this._queue;
+  }
+
+  /**
+   * @param {Store} store
+   * @param {Table} table
+   * @param {string} queueName
+   */
+  constructor(store, table, queueName = "") {
+    this.table = table;
+    this.store = store;
+    this.queueName = queueName;
+  }
+
+  async processQueue() {
+    if (!this.isProcessing && this.queue.length > 0) {
+      this.isProcessing = true;
+
+      this.setUpdateDebounceTime();
+
+      const mergedMessages = [];
+      /** @type {Array.<{key: TKey, changes: UpdateSpec}>} */
+      const indexMap = {};
+
+      // console.log(this.queueName);
+      // console.table(
+      //   this.queue.map((obj) => {
+      //     return {
+      //       index: obj.index,
+      //       content: obj.message.content,
+      //       done: obj.message.done,
+      //     };
+      //   }),
+      // );
+
+      const queueCopy = [...this.queue];
+      for (const item of queueCopy) {
+        const index = item.index;
+        if (!indexMap[index]) {
+          indexMap[index] = { key: index, changes: {} };
+          mergedMessages.push(indexMap[index]);
+        }
+        for (const propKey in item.message) {
+          indexMap[index].changes[propKey] = item.message[propKey];
+        }
+        this.queue.shift(); // remove from queue
+      }
+
+      // console.log(this.queueName + " result");
+      // console.table(
+      //   mergedMessages.map((obj) => {
+      //     return {
+      //       index: obj.key,
+      //       content: obj.changes.content,
+      //       done: obj.changes.done,
+      //     };
+      //   }),
+      // );
+
+      await this.table.bulkUpdate(mergedMessages);
+
+      this.isProcessing = false;
+    }
+    setTimeout(this.processQueue.bind(this), this.debounceTime);
+  }
+
+  setUpdateDebounceTime() {
+    if (typeof this.store.state.chat.updateDebounceInterval === "number") {
+      this.debounceTime = this.store.state.chat.updateDebounceInterval;
+    } else {
+      this.debounceTime = Queue.DEFAULT_UPDATE_DEBOUNCE_INTERVAL;
+    }
+  }
+}


### PR DESCRIPTION
Added message merging, reducing the number of updates required.

![image](https://github.com/sunner/ChatALL/assets/26683979/59f8655f-6890-47c3-804a-12d48da7e878)

For example, in the image above, currently need to update 26 times (top table), causing some delay in displaying messages when AI responds.

After add message merging, records with the same key will be merged, taking the latest value. This results in updates only 4 times (bottom table).


Also fixed anchat did not auto-scroll when AI responding in thread and did not scroll to bottom when opening chat contain thread message.

Moved the common scrolling function, used in both `ChatMessage` and `ChatThread`, to the `scroll-helper.js` file.