### PR TITLE
Replace Bard with Gemini in README and enhance Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ brew install --cask chatall
 
 Debian-based Distributions: Download the .deb file, double click it and install the software.
 Arch-based Distributions: You can clone ChatALL from the AUR [here](https://aur.archlinux.org/packages/chatall-bin). You can install it manually or using an AUR helper like yay or paru.
-Other Distributions: Download the .AppImage file, make it executable, and enjoy the click-to-run experience.
+Other Distributions: Download the .AppImage file, make it executable, and enjoy the click-to-run experience. You can also use [AppimageLauncher](https://github.com/TheAssassin/AppImageLauncher).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Typical users of ChatALL are:
 | [ChatGPT](https://chat.openai.com)                                             | Yes         | Yes         | Web Browsing, Azure OpenAI service included |
 | [Bing Chat](https://www.bing.com/new)                                          | Yes         | No API      |                                             |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                                        | No          | Yes         |                                             |
-| [Bard](https://bard.google.com/)                                               | Yes         | Coming soon |                                             |
+| [Gemini](https://gemini.google.com/)                                           | Yes         | Coming soon |                                             |
 | [Poe](https://poe.com/)                                                        | Yes         | Coming soon |                                             |
 | [MOSS](https://moss.fastnlp.top/)                                              | Yes         | No API      |                                             |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                                    | Yes         | Coming soon |                                             |
@@ -119,7 +119,8 @@ brew install --cask chatall
 
 ### On Linux
 
-Download the .AppImage file, make it executable, and enjoy the click-to-run experience.
+Debian-based Distributions: Download the .deb file, double click it and install the software.
+Other Distributions: Download the .AppImage file, make it executable, and enjoy the click-to-run experience.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ brew install --cask chatall
 ### On Linux
 
 Debian-based Distributions: Download the .deb file, double click it and install the software.
+Arch-based Distributions: You can clone ChatALL from the AUR [here](https://aur.archlinux.org/packages/chatall-bin). You can install it manually or using an AUR helper like yay or paru.
 Other Distributions: Download the .AppImage file, make it executable, and enjoy the click-to-run experience.
 
 ## Troubleshooting


### PR DESCRIPTION
Replaced Google Bard with the new and updated Google Gemini in the README, specified installation instructions for different Linux distributions.