### PR TITLE
Remove unused bots from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Typical users of ChatALL are:
 | AI Bots                                                                        | Web Access  | API         | Notes                                       |
 | ------------------------------------------------------------------------------ | ----------- | ----------- | ------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                                             | Yes         | Yes         | Web Browsing, Azure OpenAI service included |
-| [Bing Chat](https://www.bing.com/new)                                          | Yes         | No API      |                                             |
+| [Copilot](https://www.bing.com/new)                                          | Yes         | No API      |                                             |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                                        | No          | Yes         |                                             |
 | [Gemini](https://gemini.google.com/)                                           | Yes         | Coming soon |                                             |
 | [Poe](https://poe.com/)                                                        | Yes         | Coming soon |                                             |
@@ -37,8 +37,7 @@ Typical users of ChatALL are:
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                                    | Yes         | Coming soon |                                             |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)                               | Coming soon | No API      |                                             |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                                      | Yes         | Coming soon |                                             |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)                     | Yes         | No API      | No Login required                           |
-| [Vicuna 7B, 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)              | Yes         | No API      | No Login required                           |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)              | Yes         | No API      | No Login required                           |
 | [ChatGLM2 6B & 130B](https://chatglm.cn/)                                      | Yes         | No API      | No Login required                           |
 | [Claude 2 & Instant](https://www.anthropic.com/index/claude-2)                 | Yes         | No API      |                                             |
 | [Gradio](https://gradio.app/)                                                  | Yes         | No API      | For Hugging Face space/self-deployed models |
@@ -50,9 +49,9 @@ Typical users of ChatALL are:
 | [YouChat](https://you.com/)                                                    | Yes         | No API      |                                             |
 | [Open Assistant](https://open-assistant.io/)                                   | Yes         | No API      |                                             |
 | [Character.AI](https://character.ai/)                                          | Yes         | No API      |                                             |
-| [Llama 2 7B, 13B & 70B](https://ai.meta.com/llama/)                            | Yes         | No API      |                                             |
+| [Llama 2 13B & 70B](https://ai.meta.com/llama/)                            | Yes         | No API      |                                             |
 | [Code Llama](https://ai.meta.com/blog/code-llama-large-language-model-coding/) | Yes         | No API      |                                             |
-| [WizardLM 13B & 70B](https://github.com/nlpxucan/WizardLM)                     | Yes         | No API      |                                             |
+| [WizardLM 70B](https://github.com/nlpxucan/WizardLM)                     | Yes         | No API      |                                             |
 | [Falcon 180B](https://huggingface.co/tiiuae/falcon-180B-chat)                  | Yes         | No API      |                                             |
 | [Phind](https://www.phind.com/)                                                | Yes         | No API      |                                             |
 | [Zephyr](https://huggingface.co/spaces/HuggingFaceH4/zephyr-chat)              | Yes         | No API      |                                             |
@@ -180,7 +179,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Others
 
 - GPT-4 contributed much of the code
-- ChatGPT, Bing Chat and Google provide many solutions (ranked in order)
+- ChatGPT, Copilot and Google provide many solutions (ranked in order)
 - Inspired by [ChatHub](https://github.com/chathub-dev/chathub). Respect!
 
 ## Sponsor

--- a/README_DE-DE.md
+++ b/README_DE-DE.md
@@ -21,16 +21,15 @@ Auf großen Sprachmodellen (LLMs) basierende KI-Bots sind erstaunlich. Ihr Verha
 | AI Bots                                                      | Web Zugang  | API         | Notizen                                      |
 | ------------------------------------------------------------ | ----------- | ----------- | -------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | Yes         | Yes         | Web-Browsing inklusive                       |
-| [Bing Chat](https://www.bing.com/new)                        | Yes         | No API      | Kein Login erforderlich                      |
+| [Copilot](https://www.bing.com/new)                        | Yes         | No API      | Kein Login erforderlich                      |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | No          | Yes         |                                              |
-| [Bard](https://bard.google.com/)                             | Yes         | Coming soon |                                              |
+| [Gemini](https://gemini.google.com/)                             | Yes         | Coming soon |                                              |
 | [Poe](https://poe.com/)                                      | Yes         | Coming soon |                                              |
 | [MOSS](https://moss.fastnlp.top/)                            | Yes         | No API      |                                              |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | Yes         | Coming soon |                                              |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)             | Coming soon | No API      |                                              |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | Yes         | Coming soon |                                              |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | Yes         | No API      | Kein Login erforderlich                      |
-| [Vicuna](https://lmsys.org/blog/2023-03-30-vicuna/)          | Yes         | No API      | Kein Login erforderlich                      |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | Yes         | No API      | Kein Login erforderlich                      |
 | [ChatGLM](https://chatglm.cn/blog)                           | Yes         | No API      | Kein Login erforderlich                      |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | Yes         | No API      | Kein Login erforderlich                      |
 | [Gradio](https://gradio.app/)                                | Yes         | No API      | Für Hugging Face space/self-deployed Modelle |
@@ -116,7 +115,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Andere
 
 - GPT-4 hat einen Großteil des Codes beigesteuert
-- ChatGPT, Bing Chat und Google bieten viele Lösungen (in dieser Reihenfolge)
+- ChatGPT, Copilot und Google bieten viele Lösungen (in dieser Reihenfolge)
 - Inspiriert von [ChatHub](https://github.com/chathub-dev/chathub). Respekt!
 
 ## Sponsor

--- a/README_ES-ES.md
+++ b/README_ES-ES.md
@@ -29,16 +29,15 @@ Los usuarios típicos de ChatALL son:
 | Bots de IA                                                   | Acceso Web   | API          | Notas                                                |
 | ------------------------------------------------------------ | ------------ | ------------ | ---------------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | Sí           | Sí           | Exploración web, servicio Azure OpenAI incluido      |
-| [Chat de Bing](https://www.bing.com/new)                     | Sí           | Sin API      | No se requiere inicio de sesión                      |
+| [Copilot](https://www.bing.com/new)                     | Sí           | Sin API      | No se requiere inicio de sesión                      |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | No           | Sí           |                                                      |
-| [Bardo](https://bard.google.com/)                            | Sí           | Próximamente |                                                      |
+| [Gemini](https://gemini.google.com/)                            | Sí           | Próximamente |                                                      |
 | [Poe](https://poe.com/)                                      | Sí           | Próximamente |                                                      |
 | [MUSGO](https://moss.fastnlp.top/)                           | Sí           | Sin API      |                                                      |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | Sí           | Próximamente |                                                      |
 | [Asistente de aprendizaje de Dedao](https://ai.dedao.cn/)    | Próximamente | Sin API      |                                                      |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | Sí           | Próximamente |                                                      |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | Sí           | Sin API      | No se requiere inicio de sesión                      |
-| [Vicuña](https://lmsys.org/blog/2023-03-30-vicuna/)          | Sí           | Sin API      | No se requiere inicio de sesión                      |
+| [Vicuña 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | Sí           | Sin API      | No se requiere inicio de sesión                      |
 | [ChatGLM](https://chatglm.cn/blog)                           | Sí           | Sin API      | No se requiere inicio de sesión                      |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | Sí           | Sin API      | No se requiere inicio de sesión                      |
 | [Gradio](https://gradio.app/)                                | Sí           | Sin API      | Para modelos de espacio Hugging Face/autodesplegados |
@@ -165,7 +164,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Otros
 
 - GPT-4 contribuyó con gran parte del código
-- ChatGPT, Bing Chat y Google proporcionan muchas soluciones (clasificadas en orden)
+- ChatGPT, Copilot y Google proporcionan muchas soluciones (clasificadas en orden)
 - Inspirado en [ChatHub](https://github.com/chathub-dev/chathub). ¡Respeto!
 
 ## Patrocinador

--- a/README_FR-FR.md
+++ b/README_FR-FR.md
@@ -21,16 +21,15 @@ Les robots d'intelligence artificielle basés sur les grands modèles de langage
 | AI Bots                                                      | Accès web     | API           | Notes                                             |
 | ------------------------------------------------------------ | ------------- | ------------- | ------------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | Oui           | Oui           | Navigation web incluse                            |
-| [Bing Chat](https://www.bing.com/new)                        | Oui           | Non           |                                                   |
+| [Copilot](https://www.bing.com/new)                        | Oui           | Non           |                                                   |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | Non           | Oui           |                                                   |
-| [Bard](https://bard.google.com/)                             | Oui           | Non           |                                                   |
+| [Gemini](https://gemini.google.com/)                             | Oui           | Non           |                                                   |
 | [Poe](https://poe.com/)                                      | Oui           | Prochainement |                                                   |
 | [MOSS](https://moss.fastnlp.top/)                            | Oui           | Non           |                                                   |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | Oui           | Prochainement |                                                   |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)             | Prochainement | Non           |                                                   |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | Oui           | Prochainement |                                                   |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | Oui           | Non           | Pas besoin de compte ou de clé API                |
-| [Vicuna](https://lmsys.org/blog/2023-03-30-vicuna/)          | Oui           | Non           | Pas besoin de compte ou de clé API                |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | Oui           | Non           | Pas besoin de compte ou de clé API                |
 | [ChatGLM](https://chatglm.cn/blog)                           | Oui           | Non           | Pas besoin de compte ou de clé API                |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | Oui           | Non           | Pas besoin de compte ou de clé API                |
 | [Gradio](https://gradio.app/)                                | Oui           | Non           | Pour les modèles Hugging Face space/self-deployed |
@@ -114,7 +113,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Autres
 
 - GPT-4 a contribué à une grande partie du code
-- ChatGPT, Bing Chat et Google fournissent de nombreuses solutions (classées par ordre).
+- ChatGPT, Copilot et Google fournissent de nombreuses solutions (classées par ordre).
 - Inspiré par [ChatHub] (https://github.com/chathub-dev/chathub). Respect !
 
 ## Sponsor

--- a/README_IT-IT.md
+++ b/README_IT-IT.md
@@ -29,16 +29,15 @@ Gli utenti tipici di ChatALL sono:
 | IA Bots                                                      | Web Access    | API           | Notes                                        |
 | ------------------------------------------------------------ | ------------- | ------------- | -------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | Sì            | Sì            | Navigazione Web,include servizi Azure-OpenAI |
-| [Bing Chat](https://www.bing.com/new)                        | Sì            | No API        | Nessun accesso richiesto                     |
+| [Copilot](https://www.bing.com/new)                        | Sì            | No API        | Nessun accesso richiesto                     |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | No            | Si            |                                              |
-| [Bard](https://bard.google.com/)                             | Sì            | Prossimamente |                                              |
+| [Gemini](https://gemini.google.com/)                             | Sì            | Prossimamente |                                              |
 | [Poe](https://poe.com/)                                      | Sì            | Prossimamente |                                              |
 | [MOSS](https://moss.fastnlp.top/)                            | Sì            | No API        |                                              |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | Sì            | Prossimamente |                                              |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)             | Prossimamente | No API        |                                              |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | Sì            | Prossimamente |                                              |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | Sì            | No API        | Nessun accesso richiesto                     |
-| [Vicuna](https://lmsys.org/blog/2023-03-30-vicuna/)          | Sì            | No API        | Nessun accesso richiesto                     |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | Sì            | No API        | Nessun accesso richiesto                     |
 | [ChatGLM](https://chatglm.cn/blog)                           | Sì            | No API        | Nessun accesso richiesto                     |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | Sì            | No API        | Nessun accesso richiesto                     |
 | [Gradio](https://gradio.app/)                                | Sì            | No API        | Per modelli Hugging Face/spazio auto-deploy  |
@@ -105,16 +104,15 @@ Gli utenti tipici di ChatALL sono:
 | AI Bots                                                      | Accesso Web   | API           | Note                                          |
 | ------------------------------------------------------------ | ------------- | ------------- | --------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | Sì            | Sì            | Navigazione Web, include Azure OpenAI service |
-| [Bing Chat](https://www.bing.com/new)                        | Sì            | No API        | Nessun accesso richiesto                      |
+| [Copilot](https://www.bing.com/new)                        | Sì            | No API        | Nessun accesso richiesto                      |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | No            | Sì            |                                               |
-| [Bard](https://bard.google.com/)                             | Sì            | Prossimamente |                                               |
+| [Gemini](https://gemini.google.com/)                             | Sì            | Prossimamente |                                               |
 | [Poe](https://poe.com/)                                      | Sì            | Prossimamente |                                               |
 | [MOSS](https://moss.fastnlp.top/)                            | Sì            | No API        |                                               |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | Sì            | Prossimamente |                                               |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)             | Prossimamente | No API        |                                               |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | Sì            | Prossimamente |                                               |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | Sì            | No API        | Nessun accesso richiesto                      |
-| [Vicuna](https://lmsys.org/blog/2023-03-30-vicuna/)          | Sì            | No API        | Nessun accesso richiesto                      |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | Sì            | No API        | Nessun accesso richiesto                      |
 | [ChatGLM](https://chatglm.cn/blog)                           | Sì            | No API        | Nessun accesso richiesto                      |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | Sì            | No API        | Nessun accesso richiesto                      |
 | [Gradio](https://gradio.app/)                                | Sì            | No API        | Per modelli Hugging Face/spazio auto-deploy   |
@@ -235,7 +233,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Altri
 
 - GPT-4 ha contribuito gran parte del codice.
-- ChatGPT, Bing Chat e Google hanno fornito molte soluzioni (elencati in ordine).
+- ChatGPT, Copilot e Google hanno fornito molte soluzioni (elencati in ordine).
 - Progetto ispirato da [ChatHub](https://github.com/chathub-dev/chathub). Rispetto!
 
 ## Sponsor

--- a/README_JA-JP.md
+++ b/README_JA-JP.md
@@ -29,16 +29,15 @@ ChatALLのユーザーはこんな感じ：
 | 対応AI                                                       | webアクセス | API        | 確認事項                                  |
 | ------------------------------------------------------------ | ----------- | ---------- | ----------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | はい　　　  | あり　　　 | ブラウジングを含む                        |
-| [Bing Chat](https://www.bing.com/new)                        | はい　　　  | なし　　　 | ログイン不要 [ログインするとターン数上昇] |
+| [Copilot](https://www.bing.com/new)                        | はい　　　  | なし　　　 | ログイン不要 [ログインするとターン数上昇] |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | いいえ　　  | あり　　　 |                                           |
-| [Bard](https://bard.google.com/)                             | はい　　　  | 近日登場　 |                                           |
+| [Gemini](https://gemini.google.com/)                             | はい　　　  | 近日登場　 |                                           |
 | [Poe](https://poe.com/)                                      | はい　　　  | 近日登場　 |                                           |
 | [MOSS](https://moss.fastnlp.top/)                            | はい　　　  | なし　　　 |                                           |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | はい　　　  | 近日登場　 |                                           |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)             | 近日登場　  | なし　　　 |                                           |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | はい　　　  | 近日登場　 |                                           |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | はい　　　  | なし　　　 | ログイン不要                              |
-| [Vicuna](https://lmsys.org/blog/2023-03-30-vicuna/)          | はい　　　  | なし　　　 | ログイン不要                              |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | はい　　　  | なし　　　 | ログイン不要                              |
 | [ChatGLM](https://chatglm.cn/blog)                           | はい　　　  | なし　　　 | ログイン不要                              |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | はい　　　  | なし　　　 | ログイン不要                              |
 | [Gradio](https://gradio.app/)                                | はい　　　  | なし　　　 | Hugging Face space/自己配布モデル用       |
@@ -159,7 +158,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### その他
 
 - GPT-4はコードを提供した
-- ChatGPT、Bing Chat、Googleは多くの解決策を提供しています（ランキング順）
+- ChatGPT、Copilot、Googleは多くの解決策を提供しています（ランキング順）
 - [ChatHub](https://github.com/chathub-dev/chathub)のリスペクトです！
 
 ## 支援者

--- a/README_KO-KR.md
+++ b/README_KO-KR.md
@@ -29,7 +29,7 @@ ChatALL의 일반적인 사용자는 다음과 같습니다:
 | AI 봇                                                                          | 웹 액세스 | API       | 참고                                |
 | ------------------------------------------------------------------------------ | --------- | --------- | ----------------------------------- |
 | [ChatGPT](https://chat.openai.com)                                             | 예        | 예        | 웹 브라우징 포함                    |
-| [Bing Chat](https://www.bing.com/new)                                          | 예        | API 없음  | 로그인 필요 없음                    |
+| [Copilot](https://www.bing.com/new)                                          | 예        | API 없음  | 로그인 필요 없음                    |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                                        | 아니오    | 예        |                                     |
 | [Gemini](https://gemini.google.com/)                                               | 예        | API 없음  |                                     |
 | [Poe](https://poe.com/)                                                        | 예        | 근일 개봉 |                                     |
@@ -37,8 +37,7 @@ ChatALL의 일반적인 사용자는 다음과 같습니다:
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                                    | 예        | 근일 개봉 |                                     |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)                               | 근일 개봉 | API 없음  |                                     |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                                      | 예        | 근일 개봉 |                                     |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)                     | 예        | API 없음  | 로그인 필요 없음                    |
-| [Vicuna 7B, 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)                       | 예        | API 없음  | 로그인 필요 없음                    |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)                       | 예        | API 없음  | 로그인 필요 없음                    |
 | [ChatGLM2 6B & 130B](https://chatglm.cn/)                                            | 예        | API 없음  | 로그인 필요 없음                    |
 | [Claude 2 & Instant](https://www.anthropic.com/index/claude-2)                    | 예        | API 없음  | 로그인 필요 없음                   |
 | [Gradio](https://gradio.app/)                                                  | 예        | API 없음  | Hugging Face space/자체 배포 모델용 |
@@ -50,9 +49,9 @@ ChatALL의 일반적인 사용자는 다음과 같습니다:
 | [YouChat](https://you.com/)                                                    | 예        | API 없음  |                                     |
 | [Open Assistant](https://open-assistant.io/)                                   | 예        | API 없음  |                                     |
 | [Character.AI](https://character.ai/)                                          | 예        | API 없음  |                                     |
-| [Llama 2 7B, 13B & 70B](https://ai.meta.com/llama/)                            | 예        | API 없음  |                                     |
+| [Llama 2 13B & 70B](https://ai.meta.com/llama/)                            | 예        | API 없음  |                                     |
 | [Code Llama](https://ai.meta.com/blog/code-llama-large-language-model-coding/) | 예        | API 없음  |                                     |
-| [WizardLM 13B & 70B](https://github.com/nlpxucan/WizardLM)                     | 예        | API 없음  |                                     |
+| [WizardLM 70B](https://github.com/nlpxucan/WizardLM)                     | 예        | API 없음  |                                     |
 | [Falcon 180B](https://huggingface.co/tiiuae/falcon-180B-chat)                     | 예        | API 없음  |                                     |
 | [Phind](https://www.phind.com/)                                                | 예        | API 없음  |                                     |
 | [Zephyr](https://huggingface.co/spaces/HuggingFaceH4/zephyr-chat)              | 예         | API 없음     |                                             |
@@ -180,7 +179,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### 기타
 
 - GPT-4는 코드의 많은 부분을 기여했습니다
-- ChatGPT, Bing Chat 및 Google은 많은 솔루션을 제공합니다 (순서대로 나열)
+- ChatGPT, Copilot 및 Google은 많은 솔루션을 제공합니다 (순서대로 나열)
 - [ChatHub](https://github.com/chathub-dev/chathub)에서 영감을 받았습니다. 존경합니다!
 
 ## 후원

--- a/README_RU-RU.md
+++ b/README_RU-RU.md
@@ -29,16 +29,15 @@
 | ИИ-боты                                                                        | Доступ к интернету | API         | Подпись                                           |
 | ------------------------------------------------------------------------------ | ------------------ | ----------- | ------------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                                             | Да                 | Да          | Просмотр веб-страниц, включая службу Azure OpenAI |
-| [Bing Chat](https://www.bing.com/new)                                          | Да                 | Нет API     |                                                   |
+| [Copilot](https://www.bing.com/new)                                          | Да                 | Нет API     |                                                   |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                                        | Нет                | Да          |                                                   |
-| [Bard](https://bard.google.com/)                                               | Да                 | Скоро будет |                                                   |
+| [Gemini](https://gemini.google.com/)                                               | Да                 | Скоро будет |                                                   |
 | [Poe](https://poe.com/)                                                        | Да                 | Скоро будет |                                                   |
 | [MOSS](https://moss.fastnlp.top/)                                              | Да                 | Нет API     |                                                   |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                                    | Да                 | Скоро будет |                                                   |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)                               | Скоро будет        | Нет API     |                                                   |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                                      | Да                 | Скоро будет |                                                   |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)                     | Да                 | Нет API     | Вход в ученую запись не требуется                 |
-| [Vicuna 7B, 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)              | Да                 | Нет API     | Вход в ученую запись не требуется                 |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)              | Да                 | Нет API     | Вход в ученую запись не требуется                 |
 | [ChatGLM2 6B & 130B](https://chatglm.cn/)                                      | Да                 | Нет API     | Вход в ученую запись не требуется                 |
 | [Claude 2 & Instant](https://www.anthropic.com/index/claude-2)                 | Да                 | Нет API     |                                                   |
 | [Gradio](https://gradio.app/)                                                  | Да                 | Нет API     | For Hugging Face space/self-deployed models       |
@@ -50,9 +49,9 @@
 | [YouChat](https://you.com/)                                                    | Да                 | Нет API     |                                                   |
 | [Open Assistant](https://open-assistant.io/)                                   | Да                 | Нет API     |                                                   |
 | [Character.AI](https://character.ai/)                                          | Да                 | Нет API     |                                                   |
-| [Llama 2 7B, 13B & 70B](https://ai.meta.com/llama/)                            | Да                 | Нет API     |                                                   |
+| [Llama 2 13B & 70B](https://ai.meta.com/llama/)                            | Да                 | Нет API     |                                                   |
 | [Code Llama](https://ai.meta.com/blog/code-llama-large-language-model-coding/) | Да                 | Нет API     |                                                   |
-| [WizardLM 13B & 70B](https://github.com/nlpxucan/WizardLM)                     | Да                 | Нет API     |                                                   |
+| [WizardLM 70B](https://github.com/nlpxucan/WizardLM)                     | Да                 | Нет API     |                                                   |
 | [Falcon 180B](https://tiiuae-falcon-180b-demo.hf.space/)                       | Да                 | Нет API     |                                                   |
 
 Скоро будет еще больше. Проголосуйте за своих любимых ботов в [этих issues](https://github.com/sunner/ChatALL/labels/more%20LLMs).
@@ -168,7 +167,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Другие
 
 - GPT-4 внес большой вклад в разработку кода
-- ChatGPT, Bing Chat и Google предоставляют множество решений (ранжированных по порядку)
+- ChatGPT, Copilot и Google предоставляют множество решений (ранжированных по порядку)
 - Вдохновленно с помощью [ChatHub](https://github.com/chathub-dev/chathub). Респект!
 
 ## Поддержать

--- a/README_VI-VN.md
+++ b/README_VI-VN.md
@@ -21,16 +21,15 @@ Các Chat bots AI dựa trên Mô hình ngôn ngữ lớn (Large Language Models
 | AI Bots                                                      | Truy cập Web | API          | Ghi chú                                               |
 | ------------------------------------------------------------ | ------------ | ------------ | ----------------------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                           | Có           | Có           | Bao gồm cả trình duyệt Web                            |
-| [Bing Chat](https://www.bing.com/new)                        | Có           | Không có API |                                                       |
+| [Copilot](https://www.bing.com/new)                        | Có           | Không có API |                                                       |
 | [Baidu ERNIE](https://yiyan.baidu.com/)                      | No           | Có           |                                                       |
-| [Bard](https://bard.google.com/)                             | Có           | Không có API |                                                       |
+| [Gemini](https://gemini.google.com/)                             | Có           | Không có API |                                                       |
 | [Poe](https://poe.com/)                                      | Có           | Sắp ra mắt   |                                                       |
 | [MOSS](https://moss.fastnlp.top/)                            | Có           | Không có API |                                                       |
 | [Tongyi Qianwen](http://tongyi.aliyun.com/)                  | Có           | Sắp ra mắt   |                                                       |
 | [Dedao Learning Assistant](https://ai.dedao.cn/)             | Sắp ra mắt   | Không có API |                                                       |
 | [iFLYTEK SPARK](http://xinghuo.xfyun.cn/)                    | Có           | Sắp ra mắt   |                                                       |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)   | Có           | Không có API | Không yêu cầu tài khoản hoặc khóa API                 |
-| [Vicuna](https://lmsys.org/blog/2023-03-30-vicuna/)          | Có           | Không có API | Không yêu cầu tài khoản hoặc khóa API                 |
+| [Vicuna 13B & 33B](https://lmsys.org/blog/2023-03-30-vicuna/)          | Có           | Không có API | Không yêu cầu tài khoản hoặc khóa API                 |
 | [ChatGLM](https://chatglm.cn/blog)                           | Có           | Không có API | Không yêu cầu tài khoản hoặc khóa API                 |
 | [Claude](https://www.anthropic.com/index/introducing-claude) | Có           | Không có API | Không yêu cầu tài khoản hoặc khóa API                 |
 | [Gradio](https://gradio.app/)                                | Có           | Không có API | Dành cho models Hugging Face không gian/tự triển khai |
@@ -114,7 +113,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### Vài thông tin khác
 
 - GPT-4 đóng góp rất nhiều mã nguồn
-- ChatGPT, Bing Chat và Google cung cấp nhiều giải pháp (được xếp hạng theo thứ tự)
+- ChatGPT, Copilot và Google cung cấp nhiều giải pháp (được xếp hạng theo thứ tự)
 - Lấy cảm hứng từ [ChatHub](https://github.com/chathub-dev/chathub). Tôn trọng!
 
 ## Sponsor

--- a/README_ZH-CN.md
+++ b/README_ZH-CN.md
@@ -29,16 +29,15 @@ ChatALL 的典型用户是：
 | AI 机器人                                                                      | 网页访问 | API      | 说明                                     |
 | ------------------------------------------------------------------------------ | -------- | -------- | ---------------------------------------- |
 | [ChatGPT](https://chat.openai.com)                                             | 支持     | 支持     | 包含 Web Browsing、Azure OpenAI service  |
-| [Bing Chat](https://www.bing.com/new)                                          | 支持     | 无 API   | 不需要帐号                               |
+| [Copilot](https://www.bing.com/new)                                          | 支持     | 无 API   | 不需要帐号                               |
 | [文心一言](https://yiyan.baidu.com/)                                           | 否       | 支持     |                                          |
-| [Bard](https://bard.google.com/)                                               | 支持     | 即将推出 |                                          |
+| [Gemini](https://gemini.google.com/)                                               | 支持     | 即将推出 |                                          |
 | [Poe](https://poe.com/)                                                        | 支持     | 即将推出 |                                          |
 | [MOSS](https://moss.fastnlp.top/)                                              | 支持     | 无 API   |                                          |
 | [通义千问](http://tongyi.aliyun.com/)                                          | 支持     | 即将推出 |                                          |
 | [得到学习助手](https://ai.dedao.cn/)                                           | 即将推出 | 无 API   |                                          |
 | [讯飞星火](http://xinghuo.xfyun.cn/)                                           | 支持     | 即将推出 |                                          |
-| [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html)                     | 支持     | 无 API   | 不需要帐号                               |
-| [Vicuna 7B、13B 和 33B](https://lmsys.org/blog/2023-03-30-vicuna/)             | 支持     | 无 API   | 不需要帐号                               |
+| [Vicuna 13B 和 33B](https://lmsys.org/blog/2023-03-30-vicuna/)             | 支持     | 无 API   | 不需要帐号                               |
 | [ChatGLM2 6B 和 130B](https://chatglm.cn/blog)                                 | 支持     | 无 API   | 不需要帐号                               |
 | [Claude 2 和 Instant](https://www.anthropic.com/index/claude-2)                | 支持     | 无 API   | 不需要帐号                               |
 | [Gradio](httpps://gradio.app/)                                                 | 支持     | 无 API   | 用于 Hugging Face space 或自己部署的模型 |
@@ -50,9 +49,9 @@ ChatALL 的典型用户是：
 | [YouChat](https://you.com/)                                                    | 支持     | 无       |                                          |
 | [Open Assistant](https://open-assistant.io/)                                   | 支持     | 无       |                                          |
 | [Character.AI](https://character.ai/)                                          | 支持     | 无       |                                          |
-| [Llama 2 7B、13B 和 70B](https://ai.meta.com/llama/)                           | 支持     | 无 API   |                                          |
+| [Llama 2 13B 和 70B](https://ai.meta.com/llama/)                           | 支持     | 无 API   |                                          |
 | [Code Llama](https://ai.meta.com/blog/code-llama-large-language-model-coding/) | 支持     | 无 API   |                                          |
-| [WizardLM 13B 和 70B](https://github.com/nlpxucan/WizardLM)                    | 支持     | 无 API   |                                          |
+| [WizardLM 70B](https://github.com/nlpxucan/WizardLM)                    | 支持     | 无 API   |                                          |
 | [Falcon 180B](https://huggingface.co/tiiuae/falcon-180B-chat)                  | 支持     | 无 API   |                                          |
 | [Phind](https://www.phind.com/)                                                | 支持     | 无 API   |                                          |
 
@@ -177,7 +176,7 @@ npm run electron:build -- -wml --x64 --arm64
 ### 其它
 
 - GPT-4 贡献了大部分代码
-- ChatGPT，Bing Chat 和 Google 提供了许多解决方案（排名分先后）
+- ChatGPT，Copilot 和 Google 提供了许多解决方案（排名分先后）
 - 受 [ChatHub](https://github.com/chathub-dev/chathub) 启发。致敬！
 
 ## 赞助


### PR DESCRIPTION
Removed the following bots from the README, since they're no longer available in the app:
- Alpaca (removed in https://github.com/sunner/ChatALL/commit/c522fc589c380a85d09e7ab9571830e7973ad522)
- Vicuna 7B (removed in https://github.com/sunner/ChatALL/pull/738)
- Llama 2 7B (removed in https://github.com/sunner/ChatALL/pull/738)
- WizardLM 13B (removed in https://github.com/sunner/ChatALL/pull/738)

Also renamed the following:
- "Bing Chat" to "Copilot"
- "Bard" to "Gemini"