### PR TITLE
fix: first time to select kimi，wihch results a loop because of 401

### DIFF
--- a/src/bots/moonshot/KimiBot.js
+++ b/src/bots/moonshot/KimiBot.js
@@ -41,8 +41,14 @@ export default class KimiBot extends Bot {
           error.response?.status == 401 &&
           error.response?.data?.error_type == "auth.token.invalid"
         ) {
-          await this.refreshTokens();
-          available = await this._checkAvailability();
+          try {
+            await this.refreshTokens();
+            await this._checkAvailability();
+            available = true;
+          } catch (e) {
+            available = false;
+            console.error("Error checking Kimi login status:", error);
+          }
         } else {
           console.error("Error checking Kimi login status:", error);
         }
@@ -53,7 +59,7 @@ export default class KimiBot extends Bot {
 
   async refreshTokens() {
     let refreshUrl = "https://kimi.moonshot.cn/api/auth/token/refresh";
-    await axios
+    return await axios
       .get(refreshUrl, {
         headers: {
           Authorization: `Bearer ${store.state.kimi?.refresh_token}`,
@@ -64,9 +70,6 @@ export default class KimiBot extends Bot {
           access_token: response.data?.access_token,
           refresh_token: response.data?.refresh_token,
         });
-      })
-      .catch((error) => {
-        console.error("Error refreshing Kimi tokens:", error);
       });
   }
 

--- a/src/bots/moonshot/KimiBot.js
+++ b/src/bots/moonshot/KimiBot.js
@@ -30,30 +30,13 @@ export default class KimiBot extends Bot {
    */
   async _checkAvailability() {
     let available = false;
-    let userInfoUrl = "https://kimi.moonshot.cn/api/user";
-    await axios
-      .get(userInfoUrl, this.getAuthHeader())
-      .then((response) => {
-        available = response.data?.status == "normal";
-      })
-      .catch(async (error) => {
-        if (
-          error.response?.status == 401 &&
-          error.response?.data?.error_type == "auth.token.invalid"
-        ) {
-          try {
-            await this.refreshTokens();
-            await this._checkAvailability();
-            available = true;
-          } catch (e) {
-            available = false;
-            console.error("Error checking Kimi login status:", error);
-          }
-        } else {
-          console.error("Error checking Kimi login status:", error);
-        }
-      });
-
+    try {
+      await this.refreshTokens();
+      available = true;
+    } catch (e) {
+      available = false;
+      console.error("Error checking Kimi login status:", e);
+    }
     return available;
   }
 


### PR DESCRIPTION
## Reason
When you first select kimi，**https://kimi.moonshot.cn/api/user** and **https://kimi.moonshot.cn/api/auth/token/refresh**  both will return 401. 
In  **_checkAvailability** function，it will revoke itself again because of 401.

## Result
### Before
![before](https://github.com/sunner/ChatALL/assets/15937431/6d2e97b1-9cb6-485a-af57-699f17070f7d)



### After
![after](https://github.com/sunner/ChatALL/assets/15937431/be534ab9-1ccc-4df1-9b11-86759d2034a8)



