### PR TITLE
Set electronBuilder compression level to reduce the size of dist files

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -12,6 +12,7 @@ module.exports = defineConfig({
         directories: {
           buildResources: "src/assets",
         },
+        compression: "maximum",
         mac: {
           category: "public.app-category.utilities",
           target: "default",


### PR DESCRIPTION
For Linux distribution files, there's no significant size change for deb packages, but for AppImage dist files, the size is reduced from about 108MB to 70~79MB, which is good.

However, I only tested this change on the Linux platform, and I'm not sure about the outcome on macOS and Windows.