### PR TITLE
Remove incorrect linux icon config to fix linux app no icon issue

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -32,7 +32,6 @@ module.exports = defineConfig({
         },
         linux: {
           target: ["AppImage", "deb"],
-          icon: "src/assets/icon.png",
         },
         nsis: {
           oneClick: false,


### PR DESCRIPTION
According to the official electron-builder doc:

> Linux icon set will be generated automatically based on the macOS `icns` file or common `icon.png`.
>
> Or you can put them into the `build/icons` directory if you want to specify them yourself. The filename must contain the size (e.g. `256x256.png`) of the icon). Recommended sizes: 16, 32, 48, 64, 128, 256 (or just 512).

The old config is somehow wrong.

Visual comparison:

| Before | After |
| ------ | ----- |
| ![image](https://github.com/sunner/ChatALL/assets/3691490/9a34d349-2005-483f-89d3-71860bc6fc14) | ![image](https://github.com/sunner/ChatALL/assets/3691490/a6a31811-7720-4912-a858-11b5b762c0c2) |


Reference:
- https://www.electron.build/icons#linux