### PR TITLE
Fix Cohere API bot model paramater, fix #803

### DIFF
--- a/src/bots/cohere/CohereAPIBot.js
+++ b/src/bots/cohere/CohereAPIBot.js
@@ -23,7 +23,7 @@ export default class CohereAPIBot extends LangChainBot {
   _setupModel() {
     const chatModel = new ChatCohere({
       apiKey: store.state.cohereApi.apiKey,
-      modelName: this.constructor._model ? this.constructor._model : "",
+      model: this.constructor._model ? this.constructor._model : "",
       streaming: true,
       temperature: store.state.cohereApi.temperature,
     });


### PR DESCRIPTION
Sorry that I found the parameter was wrong, which caused them all to be the `command` model during use .It should be fixed with this PR.