### PR TITLE
Change to concrete extension ID in order to install VUE-devtools

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -2,7 +2,7 @@
 
 import { BrowserWindow, app, ipcMain, nativeTheme, protocol } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
-import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
+import installExtension from "electron-devtools-installer";
 import fs from "fs";
 import path from "path";
 import { setMenuItems } from "./menu";
@@ -241,9 +241,7 @@ async function createWindow() {
 
       if (
         url.startsWith("https://character.ai/_next/data/") &&
-        /^https:\/\/character\.ai\/_next\/data\/.+\/index\.json/.test(
-          url,
-        )
+        /^https:\/\/character\.ai\/_next\/data\/.+\/index\.json/.test(url)
       ) {
         const parts = url.split("/");
         if (parts.length >= 6) {
@@ -441,7 +439,7 @@ app.on("ready", async () => {
   if (isDevelopment && !process.env.IS_TEST) {
     // Install Vue Devtools
     try {
-      await installExtension(VUEJS3_DEVTOOLS);
+      await installExtension("nhdogjmejiglipccpnnnanhbledajbpd");
     } catch (e) {
       console.error("Vue Devtools failed to install:", e.toString());
     }


### PR DESCRIPTION
`Error: Invalid header: Does not start with Cr24`

This might not be the correct way to do it, but the current release doesn't work

- [github.com/electron react boilerplate/electron react boilerplate/issues/2577](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/2577?isPin=false)
- [github.com/nklayman/vue cli plugin electron builder/issues/1469](https://github.com/nklayman/vue-cli-plugin-electron-builder/issues/1469?isPin=false)

The ID used is from the latest chrome extension

![CleanShot 2024-06-12 at 13 51 20@2x](https://github.com/sunner/ChatALL/assets/142227259/d0c0cd97-fae3-438a-9eea-548c967bc616)
