### PR TITLE
Add support for Mac's Intel chips

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, macos-10.15]
 
     steps:
       - name: Checkout Git repository
@@ -37,3 +41,4 @@ jobs:
         run: |
           export PYTHON_PATH=`which python`
           npm run release
+        if: matrix.os == 'macos-latest' || matrix.os == 'macos-10.15'

--- a/vue.config.js
+++ b/vue.config.js
@@ -15,7 +15,12 @@ module.exports = defineConfig({
         compression: "maximum",
         mac: {
           category: "public.app-category.utilities",
-          target: "default",
+          target: [
+            {
+              target: "default",
+              arch: ["x64", "arm64"] // Target both Intel (x64) and Apple Silicon (arm64) architectures
+            }
+          ],
           icon: "src/assets/icon.icns",
           hardenedRuntime: true,
           notarize: {


### PR DESCRIPTION
Related to #866

This pull request introduces support for Mac's Intel chips in the ChatALL application by updating the build and release configurations.

- **Updates `vue.config.js`**: Adds support for both Intel (`x64`) and Apple Silicon (`arm64`) architectures in the macOS target configuration. This ensures the application is built for both types of chips.
- **Modifies `.github/workflows/release.yml`**: Implements a matrix strategy for the build and release job to run on both `macos-latest` and `macos-10.15`, accommodating the building and releasing of versions for Mac's Intel chips alongside Apple Silicon chips.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunner/ChatALL/issues/866?shareId=871e0fa7-7d76-4b3d-8eaf-51d408288ac9).