### PR TITLE
Fix lint-staged pattern for JSX and TSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "rules": {}
   },
   "lint-staged": {
-    "*.{js,ts,vue,jsx.tsx}": "npm run lint"
+    "*.{js,ts,vue,jsx,tsx}": "npm run lint"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Ensure lint-staged matches both .jsx and .tsx files during linting. The previous brace block used an invalid jsx.tsx extension glob.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded pre-commit linting to cover additional file types, improving consistency and code quality across the project.
  * Enhances developer workflow by catching style and syntax issues earlier.
  * No impact on app features or behavior; users should not notice any changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->