### PR TITLE
refactor: remove empty bot constructors that only call super()

### DIFF
--- a/src/bots/CharacterAIBot.js
+++ b/src/bots/CharacterAIBot.js
@@ -18,10 +18,6 @@ export default class CharacterAIBot extends Bot {
     return uuidv4().split("-").fill("vhj9cXafWcF8", 4, 5).join("-");
   }
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/ClaudeAIBot.js
+++ b/src/bots/ClaudeAIBot.js
@@ -13,10 +13,6 @@ export default class ClaudeAIBot extends Bot {
   static _loginUrl = "https://claude.ai/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/DevBot.js
+++ b/src/bots/DevBot.js
@@ -8,10 +8,6 @@ export default class DevBot extends Bot {
   static _loginUrl = "http://chatall.ai";
   static _isAvailable = true;
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/LangChainBot.js
+++ b/src/bots/LangChainBot.js
@@ -5,10 +5,6 @@ export default class LangChainBot extends Bot {
   static _brandId = "langChainBot";
   static _chatModel = undefined; // ChatModel instance
 
-  constructor() {
-    super();
-  }
-
   async _sendPrompt(prompt, onUpdateResponse, callbackParam) {
     let messages = await this.getChatContext();
     let bufferMemory = new BufferMemory();

--- a/src/bots/MOSSBot.js
+++ b/src/bots/MOSSBot.js
@@ -13,10 +13,6 @@ export default class MOSSBot extends Bot {
   static _loginUrl = "https://moss.fastnlp.top/moss/";
   static _lock = new AsyncLock();
 
-  constructor() {
-    super();
-  }
-
   getAuthHeader() {
     const token = store.state.moss?.token?.refresh;
     return {

--- a/src/bots/MistralBot.js
+++ b/src/bots/MistralBot.js
@@ -9,10 +9,6 @@ export default class MistralBot extends Bot {
   static _logoFilename = "mistral-logo.png"; // Place it in public/bots/
   static _loginUrl = "https://chat.mistral.ai/login";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
     try {

--- a/src/bots/PerplexityBot.js
+++ b/src/bots/PerplexityBot.js
@@ -11,10 +11,6 @@ export default class PerplexityBot extends Bot {
   static _isDarkLogo = true; // True if the main color of logo is dark
   static _loginUrl = "https://www.perplexity.ai";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
     try {

--- a/src/bots/PhindBot.js
+++ b/src/bots/PhindBot.js
@@ -13,10 +13,6 @@ export default class PhindBot extends Bot {
   static _loginUrl = "https://www.phind.com";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/PiBot.js
+++ b/src/bots/PiBot.js
@@ -10,10 +10,6 @@ export default class PiBot extends Bot {
   static _loginUrl = "https://pi.ai/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/QianWenBot.js
+++ b/src/bots/QianWenBot.js
@@ -19,10 +19,6 @@ export default class QianWenBot extends Bot {
   static _loginUrl = "https://qianwen.aliyun.com/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   getRequestHeaders() {
     return {
       "x-xsrf-token": store.state.qianWen?.xsrfToken,

--- a/src/bots/Qihoo360AIBrainBot.js
+++ b/src/bots/Qihoo360AIBrainBot.js
@@ -8,10 +8,6 @@ export default class Qihoo360AIBrainBot extends Bot {
   static _logoFilename = "360-ai-brain-logo.png";
   static _loginUrl = "https://chat.360.com/";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/SkyWorkBot.js
+++ b/src/bots/SkyWorkBot.js
@@ -14,10 +14,6 @@ export default class SkyWorkBot extends Bot {
 
   currentPrompt = ""; // Used by createChatContext() only
 
-  constructor() {
-    super();
-  }
-
   getAuthHeaders() {
     return {
       headers: {

--- a/src/bots/SparkBot.js
+++ b/src/bots/SparkBot.js
@@ -12,10 +12,6 @@ export default class SparkBot extends Bot {
   static _loginUrl = "https://xinghuo.xfyun.cn/";
   static _lock = new AsyncLock(); // All Spark bots share the same lock
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
     try {

--- a/src/bots/TemplateBot.js
+++ b/src/bots/TemplateBot.js
@@ -8,10 +8,6 @@ export default class YourAIBot extends Bot {
   static _loginUrl = "https://example.com/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/YouChatBot.js
+++ b/src/bots/YouChatBot.js
@@ -11,10 +11,6 @@ export default class YouChatBot extends Bot {
   static _loginUrl = "https://you.com/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/anthropic/ClaudeAPI20Bot.js
+++ b/src/bots/anthropic/ClaudeAPI20Bot.js
@@ -4,7 +4,4 @@ export default class ClaudeAPI20Bot extends ClaudeAPIBot {
   static _className = "ClaudeAPI20Bot";
   static _logoFilename = "claudeapi-20-logo.png";
   static _model = "claude-2.0";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/anthropic/ClaudeAPI21Bot.js
+++ b/src/bots/anthropic/ClaudeAPI21Bot.js
@@ -4,7 +4,4 @@ export default class ClaudeAPI21Bot extends ClaudeAPIBot {
   static _className = "ClaudeAPI21Bot";
   static _logoFilename = "claudeapi-21-logo.png";
   static _model = "claude-2.1";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/anthropic/ClaudeAPI37SonnetBot.js
+++ b/src/bots/anthropic/ClaudeAPI37SonnetBot.js
@@ -4,7 +4,4 @@ export default class ClaudeAPI37SonnetBot extends ClaudeAPIBot {
   static _className = "ClaudeAPI37SonnetBot";
   static _logoFilename = "claudeapi-37-sonnet-logo.png";
   static _model = "claude-3-7-sonnet-latest";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/anthropic/ClaudeAPIBot.js
+++ b/src/bots/anthropic/ClaudeAPIBot.js
@@ -6,10 +6,6 @@ export default class ClaudeAPIBot extends LangChainBot {
   static _brandId = "claudeApi";
   static _className = "ClaudeAPIBot";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/anthropic/ClaudeAPIHaikuBot.js
+++ b/src/bots/anthropic/ClaudeAPIHaikuBot.js
@@ -4,7 +4,4 @@ export default class ClaudeAPIHaikuBot extends ClaudeAPIBot {
   static _className = "ClaudeAPIHaikuBot";
   static _logoFilename = "claudeapi-haiku-logo.png";
   static _model = "claude-3-5-haiku-latest";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/anthropic/ClaudeAPIOpusBot.js
+++ b/src/bots/anthropic/ClaudeAPIOpusBot.js
@@ -4,7 +4,4 @@ export default class ClaudeAPIOpusBot extends ClaudeAPIBot {
   static _className = "ClaudeAPIOpusBot";
   static _logoFilename = "claudeapi-opus-logo.png";
   static _model = "claude-3-opus-20240229";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/anthropic/ClaudeAPISonnetBot.js
+++ b/src/bots/anthropic/ClaudeAPISonnetBot.js
@@ -4,7 +4,4 @@ export default class ClaudeAPISonnetBot extends ClaudeAPIBot {
   static _className = "ClaudeAPISonnetBot";
   static _logoFilename = "claudeapi-sonnet-logo.png";
   static _model = "claude-3-5-sonnet-latest";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/baidu/ERNIEBot.js
+++ b/src/bots/baidu/ERNIEBot.js
@@ -7,10 +7,6 @@ export default class ERNIEBot extends Bot {
   static _logoFilename = "ernie-logo.png"; // Place it in public/bots/
   static _loginUrl = "https://yiyan.baidu.com/";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/baidu/WenxinQianfan4Bot.js
+++ b/src/bots/baidu/WenxinQianfan4Bot.js
@@ -6,8 +6,4 @@ export default class WenxinQianfan4Bot extends WenxinQianfanBot {
   static _logoFilename = "wenxin-qianfan-4-logo.png"; // Place it in public/bots/
   static _model = "ERNIE-Bot-4"; // Model name
   static _lock = new AsyncLock();
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/baidu/WenxinQianfanBot.js
+++ b/src/bots/baidu/WenxinQianfanBot.js
@@ -10,10 +10,6 @@ export default class WenxinQianfanBot extends LangChainBot {
   static _model = "ERNIE-Bot"; // Model name
   static _lock = new AsyncLock();
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
     const { apiKey, secretKey } = store.state.wenxinQianfan;

--- a/src/bots/baidu/WenxinQianfanTurboBot.js
+++ b/src/bots/baidu/WenxinQianfanTurboBot.js
@@ -6,8 +6,4 @@ export default class WenxinQianfanTurboBot extends WenxinQianfanBot {
   static _logoFilename = "wenxin-qianfan-turbo-logo.png"; // Place it in public/bots/
   static _model = "ERNIE-Bot-turbo"; // Model name
   static _lock = new AsyncLock();
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/cohere/CohereAPIAya23Bot.js
+++ b/src/bots/cohere/CohereAPIAya23Bot.js
@@ -4,7 +4,4 @@ export default class CohereAPIAya23Bot extends CohereAPIBot {
   static _className = "CohereAPIAya23Bot";
   static _logoFilename = "cohere-logo.png";
   static _model = "c4ai-aya-23";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/cohere/CohereAPIBot.js
+++ b/src/bots/cohere/CohereAPIBot.js
@@ -6,10 +6,6 @@ export default class CohereAPIBot extends LangChainBot {
   static _brandId = "cohereApi";
   static _className = "CohereAPIBot";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/cohere/CohereAPICommandBot.js
+++ b/src/bots/cohere/CohereAPICommandBot.js
@@ -4,7 +4,4 @@ export default class CohereAPICommandBot extends CohereAPIBot {
   static _className = "CohereAPICommandBot";
   static _logoFilename = "cohere-logo.png";
   static _model = "command";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/cohere/CohereAPICommandLightBot.js
+++ b/src/bots/cohere/CohereAPICommandLightBot.js
@@ -4,7 +4,4 @@ export default class CohereAPICommandLightBot extends CohereAPIBot {
   static _className = "CohereAPICommandLightBot";
   static _logoFilename = "cohere-logo.png";
   static _model = "command-light";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/cohere/CohereAPICommandRBot.js
+++ b/src/bots/cohere/CohereAPICommandRBot.js
@@ -4,7 +4,4 @@ export default class CohereAPICommandRBot extends CohereAPIBot {
   static _className = "CohereAPICommandRBot";
   static _logoFilename = "cohere-logo.png";
   static _model = "command-r";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/cohere/CohereAPICommandRPlusBot.js
+++ b/src/bots/cohere/CohereAPICommandRPlusBot.js
@@ -4,7 +4,4 @@ export default class CohereAPICommandRPlusBot extends CohereAPIBot {
   static _className = "CohereAPICommandRPlusBot";
   static _logoFilename = "cohere-logo.png";
   static _model = "command-r-plus";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/google/BardBot.js
+++ b/src/bots/google/BardBot.js
@@ -149,10 +149,6 @@ export default class BardBot extends Bot {
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) chatall/1.29.40 Chrome/114.0.5735.134 Safari/537.36";
   static _lock = new AsyncLock();
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     const context = await this.getChatContext();
     let available = false;

--- a/src/bots/google/Gemini15FlashAPIBot.js
+++ b/src/bots/google/Gemini15FlashAPIBot.js
@@ -4,8 +4,4 @@ export default class Gemini15FlashAPIBot extends GeminiAPIBot {
   static _className = "Gemini15FlashAPIBot";
   static _logoFilename = "gemini-1.5-flash-logo.png";
   static _model = "gemini-1.5-flash-latest";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/google/Gemini15ProAPIBot.js
+++ b/src/bots/google/Gemini15ProAPIBot.js
@@ -4,8 +4,4 @@ export default class Gemini15ProAPIBot extends GeminiAPIBot {
   static _className = "Gemini15ProAPIBot";
   static _logoFilename = "gemini-1.5-logo.png"; // Place it in public/bots/
   static _model = "gemini-1.5-pro-latest";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/google/Gemini20FlashAPIBot.js
+++ b/src/bots/google/Gemini20FlashAPIBot.js
@@ -4,8 +4,4 @@ export default class Gemini20FlashAPIBot extends GeminiAPIBot {
   static _className = "Gemini20FlashAPIBot";
   static _logoFilename = "gemini-2.0-flash-logo.png";
   static _model = "gemini-2.0-flash-001";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/google/Gemini20FlashLiteAPIBot.js
+++ b/src/bots/google/Gemini20FlashLiteAPIBot.js
@@ -4,8 +4,4 @@ export default class Gemini20FlashLiteAPIBot extends GeminiAPIBot {
   static _className = "Gemini20FlashLiteAPIBot";
   static _logoFilename = "gemini-2.0-flash-lite-logo.png";
   static _model = "gemini-2.0-flash-lite";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/google/GeminiAPIBot.js
+++ b/src/bots/google/GeminiAPIBot.js
@@ -8,10 +8,6 @@ export default class GeminiAPIBot extends LangChainBot {
   static _logoFilename = "gemini-1.0-logo.png"; // Place it in public/bots/
   static _model = "gemini-pro";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/google/GeminiAdvBot.js
+++ b/src/bots/google/GeminiAdvBot.js
@@ -5,8 +5,4 @@ export default class GeminiAdvBot extends BardBot {
   static _className = "GeminiAdvBot"; // Class name of the bot
   static _model = "gemini-ultra"; // gemini-pro or gemini-ultra
   static _logoFilename = "gemini-chat-adv-logo.svg"; // Place it in public/bots/
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/groq/Gemma29bGroqAPIBot.js
+++ b/src/bots/groq/Gemma29bGroqAPIBot.js
@@ -4,7 +4,4 @@ export default class Gemma29bGroqAPIBot extends GroqAPIBot {
   static _className = "Gemma29bGroqAPIBot";
   static _logoFilename = "gemma2-9b-it-groq-logo.png";
   static _model = "gemma2-9b-it";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/groq/Gemma7bGroqAPIBot.js
+++ b/src/bots/groq/Gemma7bGroqAPIBot.js
@@ -4,7 +4,4 @@ export default class Gemma7bGroqAPIBot extends GroqAPIBot {
   static _className = "Gemma7bGroqAPIBot";
   static _logoFilename = "gemma-7b-it-groq-logo.png";
   static _model = "gemma-7b-it";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/groq/GroqAPIBot.js
+++ b/src/bots/groq/GroqAPIBot.js
@@ -6,10 +6,6 @@ export default class GroqAPIBot extends LangChainBot {
   static _brandId = "groqApi";
   static _className = "GroqAPIBot";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/groq/Llama370bGroqAPIBot.js
+++ b/src/bots/groq/Llama370bGroqAPIBot.js
@@ -4,7 +4,4 @@ export default class Llama370bGroqAPIBot extends GroqAPIBot {
   static _className = "Llama370bGroqAPIBot";
   static _logoFilename = "llama-3-70b-groq-logo.png";
   static _model = "llama3-70b-8192";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/groq/Llama38bGroqAPIBot.js
+++ b/src/bots/groq/Llama38bGroqAPIBot.js
@@ -4,7 +4,4 @@ export default class Llama38bGroqAPIBot extends GroqAPIBot {
   static _className = "Llama38bGroqAPIBot";
   static _logoFilename = "llama-3-8b-groq-logo.png";
   static _model = "llama3-8b-8192";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/groq/Llama4MaverickGroqAPIBot.js
+++ b/src/bots/groq/Llama4MaverickGroqAPIBot.js
@@ -4,7 +4,4 @@ export default class Llama4MaverickGroqAPIBot extends GroqAPIBot {
   static _className = "Llama4MaverickGroqAPIBot";
   static _logoFilename = "llama-4-maverick-groq-logo.png";
   static _model = "meta-llama/llama-4-maverick-17b-128e-instruct";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/groq/Llama4ScoutGroqAPIBot.js
+++ b/src/bots/groq/Llama4ScoutGroqAPIBot.js
@@ -4,7 +4,4 @@ export default class Llama4ScoutGroqAPIBot extends GroqAPIBot {
   static _className = "Llama4ScoutGroqAPIBot";
   static _logoFilename = "llama-4-scout-groq-logo.png";
   static _model = "meta-llama/llama-4-scout-17b-16e-instruct";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/huggingface/GradioBot.js
+++ b/src/bots/huggingface/GradioBot.js
@@ -13,10 +13,6 @@ export default class GradioBot extends Bot {
   config = {};
   eventListeners = new Map();
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/huggingface/HuggingChatBot.js
+++ b/src/bots/huggingface/HuggingChatBot.js
@@ -12,10 +12,6 @@ export default class HuggingChatBot extends Bot {
   static _model = "OpenAssistant/oasst-sft-6-llama-30b-xor";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   /**
    * Check whether the bot is logged in, settings are correct, etc.
    * @returns {boolean} - true if the bot is available, false otherwise.

--- a/src/bots/lmsys/LMSYSBot.js
+++ b/src/bots/lmsys/LMSYSBot.js
@@ -14,10 +14,6 @@ export default class LMSYSBot extends GradioBot {
   static _fnIndexes = [41, 42]; // Indexes of the APIs to call in order. Sniffer it by devtools.
   _triggerId = 93; // From devtools
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = await super._checkAvailability();
     if (available) {

--- a/src/bots/microsoft/AzureOpenAIAPIBot.js
+++ b/src/bots/microsoft/AzureOpenAIAPIBot.js
@@ -8,10 +8,6 @@ export default class AzureOpenAIAPIBot extends LangChainBot {
   static _logoFilename = "azure-openai-logo.png";
   static _isDarkLogo = true; // The main color of logo is dark
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
     if (

--- a/src/bots/microsoft/BingChatBalancedBot.js
+++ b/src/bots/microsoft/BingChatBalancedBot.js
@@ -26,8 +26,4 @@ export default class BingChatBalancedBot extends BingChatBot {
     "saharagenconv5",
   ];
   static _tone = "Balanced";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/microsoft/BingChatBot.js
+++ b/src/bots/microsoft/BingChatBot.js
@@ -13,10 +13,6 @@ export default class BingChatBot extends Bot {
   static _optionsSets = null; // Set by the subclass
   static _tone = ""; // Set by the subclass
 
-  constructor() {
-    super();
-  }
-
   async createChatContext() {
     const headers = {
       "x-ms-client-request-id": uuidv4(),

--- a/src/bots/microsoft/BingChatCreativeBot.js
+++ b/src/bots/microsoft/BingChatCreativeBot.js
@@ -29,8 +29,4 @@ export default class BingChatCreativeBot extends BingChatBot {
     "gencontentv3",
   ];
   static _tone = "Creative";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/microsoft/BingChatPreciseBot.js
+++ b/src/bots/microsoft/BingChatPreciseBot.js
@@ -29,8 +29,4 @@ export default class BingChatPreciseBot extends BingChatBot {
     "enable_user_consent",
   ];
   static _tone = "Precise";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/moonshot/KimiBot.js
+++ b/src/bots/moonshot/KimiBot.js
@@ -12,10 +12,6 @@ export default class KimiBot extends Bot {
   static _loginUrl = "https://kimi.moonshot.cn/";
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   getAuthHeader() {
     return {
       headers: {

--- a/src/bots/openai/ChatGPT4Bot.js
+++ b/src/bots/openai/ChatGPT4Bot.js
@@ -6,10 +6,6 @@ export default class ChatGPT4Bot extends ChatGPTBot {
   static _logoFilename = "chatgpt-4-logo.png"; // Place it in public/bots/
   static _model = "gpt-4";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = await super._checkAvailability();
 

--- a/src/bots/openai/OpenAIAPI35Bot.js
+++ b/src/bots/openai/OpenAIAPI35Bot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI35Bot extends OpenAIAPIBot {
   static _logoFilename = "openai-35-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-3.5-turbo";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI4128KBot.js
+++ b/src/bots/openai/OpenAIAPI4128KBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI4128KBot extends OpenAIAPIBot {
   static _logoFilename = "openai-4-128k-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4-turbo";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI41Bot.js
+++ b/src/bots/openai/OpenAIAPI41Bot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI41Bot extends OpenAIAPIBot {
   static _logoFilename = "openai-41-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4.1";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI41MiniBot.js
+++ b/src/bots/openai/OpenAIAPI41MiniBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI41MiniBot extends OpenAIAPIBot {
   static _logoFilename = "openai-41-mini-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4.1-mini";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI41NanoBot.js
+++ b/src/bots/openai/OpenAIAPI41NanoBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI41NanoBot extends OpenAIAPIBot {
   static _logoFilename = "openai-41-nano-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4.1-nano";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI45Bot.js
+++ b/src/bots/openai/OpenAIAPI45Bot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI45Bot extends OpenAIAPIBot {
   static _logoFilename = "openai-45-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4.5-preview";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI4Bot.js
+++ b/src/bots/openai/OpenAIAPI4Bot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI4Bot extends OpenAIAPIBot {
   static _logoFilename = "openai-4-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI4oBot.js
+++ b/src/bots/openai/OpenAIAPI4oBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI4oBot extends OpenAIAPIBot {
   static _logoFilename = "openai-4o-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4o";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPI4oMiniBot.js
+++ b/src/bots/openai/OpenAIAPI4oMiniBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPI4oMiniBot extends OpenAIAPIBot {
   static _logoFilename = "openai-4o-mini-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "gpt-4o-mini";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPIBot.js
+++ b/src/bots/openai/OpenAIAPIBot.js
@@ -6,10 +6,6 @@ export default class OpenAIAPIBot extends LangChainBot {
   static _brandId = "openaiApi";
   static _className = "OpenAIAPIBot";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/openai/OpenAIAPIo1Bot.js
+++ b/src/bots/openai/OpenAIAPIo1Bot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPIo1Bot extends OpenAIAPIBot {
   static _logoFilename = "openai-o1-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "o1";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPIo1MiniBot.js
+++ b/src/bots/openai/OpenAIAPIo1MiniBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPIo1MiniBot extends OpenAIAPIBot {
   static _logoFilename = "openai-o1-mini-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "o1-mini";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPIo3Bot.js
+++ b/src/bots/openai/OpenAIAPIo3Bot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPIo3Bot extends OpenAIAPIBot {
   static _logoFilename = "openai-o3-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "o3";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPIo3MiniBot.js
+++ b/src/bots/openai/OpenAIAPIo3MiniBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPIo3MiniBot extends OpenAIAPIBot {
   static _logoFilename = "openai-o3-mini-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "o3-mini";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/openai/OpenAIAPIo4MiniBot.js
+++ b/src/bots/openai/OpenAIAPIo4MiniBot.js
@@ -5,8 +5,4 @@ export default class OpenAIAPIo4MiniBot extends OpenAIAPIBot {
   static _logoFilename = "openai-o4-mini-logo.png"; // Place it in public/bots/
   static _isDarkLogo = true; // The main color of logo is dark
   static _model = "o4-mini";
-
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/poe/PoeBot.js
+++ b/src/bots/poe/PoeBot.js
@@ -19,10 +19,6 @@ export default class PoeBot extends Bot {
     lastMessageId: 0,
   };
 
-  constructor() {
-    super();
-  }
-
   async gqlPost(queryName, variables) {
     const { settings } = this.context;
     const formkey = store.state.poe.formkey;

--- a/src/bots/xai/Grok2APIBot.js
+++ b/src/bots/xai/Grok2APIBot.js
@@ -4,7 +4,4 @@ export default class Grok2APIBot extends xAIAPIBot {
   static _className = "Grok2APIBot";
   static _logoFilename = "grok-2-logo.png";
   static _model = "grok-2-latest";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/xai/Grok3APIBot.js
+++ b/src/bots/xai/Grok3APIBot.js
@@ -4,7 +4,4 @@ export default class Grok3APIBot extends xAIAPIBot {
   static _className = "Grok3APIBot";
   static _logoFilename = "grok-3-logo.png";
   static _model = "grok-3";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/xai/Grok3MiniAPIBot.js
+++ b/src/bots/xai/Grok3MiniAPIBot.js
@@ -4,7 +4,4 @@ export default class Grok3MiniAPIBot extends xAIAPIBot {
   static _className = "Grok3MiniAPIBot";
   static _logoFilename = "grok-3-mini-logo.png";
   static _model = "grok-3-mini";
-  constructor() {
-    super();
-  }
 }

--- a/src/bots/xai/xAIAPIBot.js
+++ b/src/bots/xai/xAIAPIBot.js
@@ -6,10 +6,6 @@ export default class xAIAPIBot extends LangChainBot {
   static _brandId = "xaiApi";
   static _className = "xAIAPIBot";
 
-  constructor() {
-    super();
-  }
-
   async _checkAvailability() {
     let available = false;
 

--- a/src/bots/zhipu/ChatGLM4Bot.js
+++ b/src/bots/zhipu/ChatGLM4Bot.js
@@ -7,10 +7,6 @@ export default class ChatGLM4Bot extends ChatGLMBot {
   static _logoFilename = "chatglm-4-logo.png"; // Place it in public/bots/
   static _model = "GLM-4"; // Model name
 
-  constructor() {
-    super();
-  }
-
   /**
    * Send a prompt to the bot and call onResponse(response, callbackParam)
    * when the response is ready.

--- a/src/bots/zhipu/ChatGLMBot.js
+++ b/src/bots/zhipu/ChatGLMBot.js
@@ -13,10 +13,6 @@ export default class ChatGLMBot extends Bot {
   static _model = "GLM-3"; // Model name
   static _lock = new AsyncLock(); // AsyncLock for prompt requests
 
-  constructor() {
-    super();
-  }
-
   getAuthHeader() {
     return {
       headers: {


### PR DESCRIPTION
Fixes #1008

## Problem

Many bot files contain boilerplate constructors that only call `super()` with no additional initialization logic:

```javascript
constructor() {
  super();
}
```

This was flagged in #1005 and #1012 by CodeRabbit and tracked in issue #1008. JavaScript classes automatically invoke the parent constructor when no constructor is defined, making these redundant.

## Solution

Removed the empty `constructor() { super(); }` blocks from 78 bot files across the codebase. The behavior is identical — JavaScript's default constructor calls `super()` automatically for derived classes.

## Testing

- Verified that only pure boilerplate constructors (those with exactly one `super()` call and nothing else) were removed
- No constructor with additional logic was touched
- The 78 affected files span all bot categories: OpenAI, Anthropic, Google, xAI, Groq, Cohere, Baidu, Microsoft, HuggingFace, and others

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed redundant explicit constructors across bot classes throughout the codebase. All affected classes previously only called the parent constructor without adding custom logic. They now rely on inherited default constructor behavior, reducing code complexity and improving maintainability with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->