### PR TITLE
fix: use correct WebSocket transport and improve error message in PerplexityBot

### DIFF
--- a/src/bots/PerplexityBot.js
+++ b/src/bots/PerplexityBot.js
@@ -3,6 +3,7 @@ import Bot from "@/bots/Bot";
 import axios from "axios";
 import { v4 as uuidv4 } from "uuid";
 import WebSocketAsPromised from "websocket-as-promised";
+import i18n from "@/i18n";
 
 export default class PerplexityBot extends Bot {
   static _brandId = "perplexity";
@@ -174,7 +175,7 @@ export default class PerplexityBot extends Bot {
     return new Promise((resolve, reject) => {
       try {
         const wsp = new WebSocketAsPromised(
-          `wss://www.perplexity.ai/socket.io/?EIO=4&transport=polling&t=${this.t}&sid=${sid}`,
+          `wss://www.perplexity.ai/socket.io/?EIO=4&transport=websocket&t=${this.t}&sid=${sid}`,
           {
             packMessage: (data) => {
               return `42${this.seq++}${JSON.stringify(data)}`;
@@ -309,7 +310,11 @@ export default class PerplexityBot extends Bot {
         wsp.onError.addListener((event) => {
           wsp.removeAllListeners();
           wsp.close();
-          reject(event);
+          reject(
+            i18n.global.t("error.failedConnectUrl", {
+              url: event.target?.url ?? "wss://www.perplexity.ai/socket.io/",
+            }),
+          );
         });
 
         wsp.onClose.addListener(() => {


### PR DESCRIPTION
Fixes #925

## Problem

The Perplexity bot was showing `[object Event]` as the error message when the WebSocket connection failed. There were two bugs:

1. The WebSocket URL used `transport=polling` instead of the correct `transport=websocket` for a WebSocket connection. In socket.io's upgrade flow, the WebSocket endpoint must specify `transport=websocket` — using `transport=polling` causes the server to reject or mishandle the upgrade, leading to connection failure.

2. When the connection failed, `reject(event)` passed a raw DOM `Event` object to the rejection handler. When converted to a string via `toString()`, it produces `"[object Event]"` — an unhelpful error message shown to users.

## Solution

- Change the WebSocket URL from `transport=polling` to `transport=websocket`
- Replace `reject(event)` with a localized error message using `i18n.global.t("error.failedConnectUrl")`, consistent with the pattern already used in `MOSSBot.js`

## Testing

The fix aligns the WebSocket transport with what socket.io expects for a WebSocket upgrade, and ensures error messages are human-readable when the connection fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability through optimized transport protocol
  * Enhanced error handling with localized, user-friendly error messages for better clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->