### PR TITLE
Add Atlas Cloud API bots

### DIFF
--- a/src/bots/atlascloud/AtlasCloudAPIBot.js
+++ b/src/bots/atlascloud/AtlasCloudAPIBot.js
@@ -1,0 +1,43 @@
+import LangChainBot from "@/bots/LangChainBot";
+import store from "@/store";
+import { ChatOpenAI } from "@langchain/openai";
+
+export default class AtlasCloudAPIBot extends LangChainBot {
+  static _brandId = "atlasCloudApi";
+  static _className = "AtlasCloudAPIBot";
+  static _logoFilename = "default-logo.svg";
+
+  constructor() {
+    super();
+  }
+
+  async _checkAvailability() {
+    let available = false;
+
+    if (store.state.atlasCloudApi.apiKey) {
+      this.setupModel();
+      available = true;
+    }
+    return available;
+  }
+
+  _setupModel() {
+    const chatModel = new ChatOpenAI({
+      configuration: {
+        basePath: "https://api.atlascloud.ai/v1",
+      },
+      openAIApiKey: store.state.atlasCloudApi.apiKey,
+      modelName: this.constructor._model ? this.constructor._model : "",
+      temperature: store.state.atlasCloudApi.temperature,
+      maxTokens: store.state.atlasCloudApi.maxTokens,
+      streaming: true,
+    });
+    return chatModel;
+  }
+
+  getPastRounds() {
+    return store.state.atlasCloudApi.pastRounds
+      ? store.state.atlasCloudApi.pastRounds
+      : 5;
+  }
+}

--- a/src/bots/atlascloud/AtlasCloudAPIBot.js
+++ b/src/bots/atlascloud/AtlasCloudAPIBot.js
@@ -24,7 +24,7 @@ export default class AtlasCloudAPIBot extends LangChainBot {
   _setupModel() {
     const chatModel = new ChatOpenAI({
       configuration: {
-        basePath: "https://api.atlascloud.ai/v1",
+        baseURL: "https://api.atlascloud.ai/v1",
       },
       openAIApiKey: store.state.atlasCloudApi.apiKey,
       modelName: this.constructor._model ? this.constructor._model : "",
@@ -36,8 +36,6 @@ export default class AtlasCloudAPIBot extends LangChainBot {
   }
 
   getPastRounds() {
-    return store.state.atlasCloudApi.pastRounds
-      ? store.state.atlasCloudApi.pastRounds
-      : 5;
+    return store.state.atlasCloudApi.pastRounds ?? 5;
   }
 }

--- a/src/bots/atlascloud/AtlasCloudDeepSeekV4ProBot.js
+++ b/src/bots/atlascloud/AtlasCloudDeepSeekV4ProBot.js
@@ -1,0 +1,10 @@
+import AtlasCloudAPIBot from "./AtlasCloudAPIBot";
+
+export default class AtlasCloudDeepSeekV4ProBot extends AtlasCloudAPIBot {
+  static _className = "AtlasCloudDeepSeekV4ProBot";
+  static _model = "deepseek-ai/deepseek-v4-pro";
+
+  constructor() {
+    super();
+  }
+}

--- a/src/bots/atlascloud/AtlasCloudQwen35FlashBot.js
+++ b/src/bots/atlascloud/AtlasCloudQwen35FlashBot.js
@@ -1,0 +1,10 @@
+import AtlasCloudAPIBot from "./AtlasCloudAPIBot";
+
+export default class AtlasCloudQwen35FlashBot extends AtlasCloudAPIBot {
+  static _className = "AtlasCloudQwen35FlashBot";
+  static _model = "qwen/qwen3.5-flash";
+
+  constructor() {
+    super();
+  }
+}

--- a/src/bots/index.js
+++ b/src/bots/index.js
@@ -66,6 +66,8 @@ import ClaudeAPIHaikuBot from "./anthropic/ClaudeAPIHaikuBot";
 import Grok2APIBot from "./xai/Grok2APIBot";
 import Grok3APIBot from "./xai/Grok3APIBot";
 import Grok3MiniAPIBot from "./xai/Grok3MiniAPIBot";
+import AtlasCloudQwen35FlashBot from "./atlascloud/AtlasCloudQwen35FlashBot";
+import AtlasCloudDeepSeekV4ProBot from "./atlascloud/AtlasCloudDeepSeekV4ProBot";
 
 const all = [
   Qihoo360AIBrainBot.getInstance(),
@@ -134,6 +136,8 @@ const all = [
   Grok2APIBot.getInstance(),
   Grok3APIBot.getInstance(),
   Grok3MiniAPIBot.getInstance(),
+  AtlasCloudQwen35FlashBot.getInstance(),
+  AtlasCloudDeepSeekV4ProBot.getInstance(),
 ];
 
 const disabled = ["HuggingChatBot"];
@@ -230,6 +234,8 @@ export const botTags = {
     bots.getBotByClassName("Grok2APIBot"),
     bots.getBotByClassName("Grok3APIBot"),
     bots.getBotByClassName("Grok3MiniAPIBot"),
+    bots.getBotByClassName("AtlasCloudQwen35FlashBot"),
+    bots.getBotByClassName("AtlasCloudDeepSeekV4ProBot"),
   ],
   madeInChina: [
     bots.getBotByClassName("Qihoo360AIBrainBot"),

--- a/src/components/BotSettings/AtlasCloudAPIBotSettings.vue
+++ b/src/components/BotSettings/AtlasCloudAPIBotSettings.vue
@@ -1,0 +1,75 @@
+<template>
+   <CommonBotSettings
+    :settings="settings"
+    :brand-id="brandId"
+    mutation-type="setAtlasCloudApi"
+    :watcher="watcher"
+  ></CommonBotSettings
+  >
+</template>
+
+<script>
+import _bots from "@/bots";
+import Bot from "@/bots/atlascloud/AtlasCloudAPIBot";
+import CommonBotSettings from "@/components/BotSettings/CommonBotSettings.vue";
+import { Type } from "./settings.const";
+
+const settings = [
+  {
+    type: Type.Text,
+    name: "apiKey",
+    title: "common.apiKey",
+    description: "settings.secretPrompt",
+    placeholder: "ak-...",
+  },
+  {
+    type: Type.Slider,
+    name: "temperature",
+    title: "openaiApi.temperature",
+    description: "openaiApi.temperaturePrompt",
+    min: 0,
+    max: 2,
+    step: 0.1,
+    ticks: {
+      0: "openaiApi.temperature0",
+      2: "openaiApi.temperature2",
+    },
+  },
+  {
+    type: Type.Slider,
+    name: "maxTokens",
+    title: "claudeApi.maxTokens",
+    description: "claudeApi.maxTokensPrompt",
+    min: 512,
+    max: 8192,
+    step: 512,
+  },
+  {
+    type: Type.Slider,
+    name: "pastRounds",
+    title: "bot.pastRounds",
+    description: "bot.pastRoundsPrompt",
+    min: 0,
+    max: 10,
+    step: 1,
+  },
+];
+export default {
+  components: {
+    CommonBotSettings,
+  },
+  data() {
+    return {
+      settings: settings,
+      brandId: Bot._brandId,
+    };
+  },
+  methods: {
+    watcher() {
+      _bots.all
+        .filter((bot) => bot instanceof Bot)
+        .map((bot) => bot.setupModel());
+    },
+  },
+};
+</script>

--- a/src/components/BotSettings/AtlasCloudAPIBotSettings.vue
+++ b/src/components/BotSettings/AtlasCloudAPIBotSettings.vue
@@ -4,8 +4,7 @@
     :brand-id="brandId"
     mutation-type="setAtlasCloudApi"
     :watcher="watcher"
-  ></CommonBotSettings
-  >
+  />
 </template>
 
 <script>
@@ -68,8 +67,9 @@ export default {
     watcher() {
       _bots.all
         .filter((bot) => bot instanceof Bot)
-        .map((bot) => bot.setupModel());
+        .forEach((bot) => bot.setupModel());
     },
   },
 };
 </script>
+

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -128,6 +128,7 @@ import { resolveTheme, applyTheme, Mode } from "../theme";
 import ClaudeAPIBotSettings from "./BotSettings/ClaudeAPIBotSettings.vue";
 import GroqAPIBotSettings from "./BotSettings/GroqAPIBotSettings.vue";
 import xAIAPIBotSettings from "./BotSettings/xAIAPIBotSettings.vue";
+import AtlasCloudAPIBotSettings from "./BotSettings/AtlasCloudAPIBotSettings.vue";
 
 const { ipcRenderer } = window.require("electron");
 const { t: $t, locale } = useI18n();
@@ -142,6 +143,7 @@ const tab = ref(null);
 const botSettings = [
   { brand: "360AiBrain", component: Qihoo360AIBrainBotSettings },
   { brand: "azureOpenaiApi", component: AzureOpenAIAPIBotSettings },
+  { brand: "atlasCloudApi", component: AtlasCloudAPIBotSettings },
   { brand: "bard", component: BardBotSettings },
   { brand: "bingChat", component: BingChatBotSettings },
   { brand: "characterAI", component: CharacterAIBotSettings },
@@ -240,4 +242,3 @@ watch(
   text-transform: none !important;
 }
 </style>
-

--- a/src/components/SettingsModal.vue
+++ b/src/components/SettingsModal.vue
@@ -242,3 +242,4 @@ watch(
   text-transform: none !important;
 }
 </style>
+

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -317,6 +317,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -316,6 +316,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -317,6 +317,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -293,6 +293,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/i18n/locales/zhtw.json
+++ b/src/i18n/locales/zhtw.json
@@ -314,6 +314,11 @@
     "gemma-7b-it": "Gemma 7b",
     "gemma2-9b-it": "Gemma2 9b"
   },
+  "atlasCloudApi": {
+    "name": "Atlas Cloud API",
+    "qwenqwen35-flash": "Qwen3.5 Flash",
+    "deepseek-aideepseek-v4-pro": "DeepSeek V4 Pro"
+  },
   "xaiApi": {
     "name": "xAI API",
     "grok-2-latest": "Grok-2",

--- a/src/store/chats.js
+++ b/src/store/chats.js
@@ -27,6 +27,8 @@ class Chats {
             { classname: "Grok3MiniAPIBot", selected: false },
             { classname: "Llama4ScoutGroqAPIBot", selected: false },
             { classname: "Llama4MaverickGroqAPIBot", selected: false },
+            { classname: "AtlasCloudQwen35FlashBot", selected: false },
+            { classname: "AtlasCloudDeepSeekV4ProBot", selected: false },
             { classname: "OpenAIAPI41Bot", selected: false },
             { classname: "OpenAIAPI41MiniBot", selected: false },
             { classname: "OpenAIAPI41NanoBot", selected: false },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -126,6 +126,12 @@ export default createStore({
       apiKey: "",
       pastRounds: 5,
     },
+    atlasCloudApi: {
+      apiKey: "",
+      temperature: 0.7,
+      maxTokens: 1024,
+      pastRounds: 5,
+    },
     currentChatIndex: 0,
     updateCounter: 0,
     theme: undefined,
@@ -276,6 +282,9 @@ export default createStore({
     },
     setXaiApi(state, values) {
       state.xaiApi = { ...state.xaiApi, ...values };
+    },
+    setAtlasCloudApi(state, values) {
+      state.atlasCloudApi = { ...state.atlasCloudApi, ...values };
     },
     setLatestPromptIndex(state, promptIndex) {
       Chats.table.update(state.currentChatIndex, {


### PR DESCRIPTION
## Summary
- add Atlas Cloud as an OpenAI-compatible API bot provider
- add Qwen3.5 Flash and DeepSeek V4 Pro Atlas Cloud bot entries
- wire Atlas Cloud into bot settings, defaults, API bot tags, and locale labels

## Validation
- npx eslint src/bots/atlascloud/AtlasCloudAPIBot.js src/bots/atlascloud/AtlasCloudQwen35FlashBot.js src/bots/atlascloud/AtlasCloudDeepSeekV4ProBot.js src/bots/index.js src/store/index.js src/store/chats.js
- python3 -m json.tool src/i18n/locales/*.json
- git diff --check

`npm ci --ignore-scripts` could not run because the current package-lock is out of sync with package.json. `npm run build` also fails in this local install with Webpack `node:` scheme errors from resolved dependencies, so I kept validation focused on the changed source and JSON files.

No README changes. No sponsor, logo, credits, or partner placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Atlas Cloud API integration with Qwen3.5 Flash and DeepSeek V4 Pro bots.
  - Introduced a new Atlas Cloud bot configuration for managing credentials and generation parameters.
- **Localization**
  - Added Atlas Cloud API and model names across supported languages.
- **User Experience**
  - Added Atlas Cloud settings to the settings modal.
  - Atlas Cloud bot availability updates automatically based on the configured API key.
- **Chores**
  - Seeded Atlas Cloud bots into the initial chat when no chats exist yet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->